### PR TITLE
[Backport] Add spelling correction: formatedPrice to formattedPrice

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/Section/AdminPromptModalSection.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Section/AdminPromptModalSection.xml
@@ -5,12 +5,11 @@
   * See COPYING.txt for license details.
   */
 -->
+
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
-    <section name="StorefrontHeaderSection">
-        <element name="storeViewSwitcher" type="button" selector="#switcher-language-trigger"/>
-        <element name="storeViewDropdown" type="button" selector="ul.switcher-dropdown"/>
-        <element name="storeViewOption" type="button" selector="li.view-{{var1}}>a" parameterized="true"/>
-        <element name="mainTitle" type="text" selector="#maincontent .page-title"/>
+    <section name="AdminPromptModalSection">
+        <element name="promptField" type="input" selector="input[data-role='promptField']"/>
+        <element name="modalOk" type="button" selector="aside.prompt .modal-footer button.action-accept" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -181,7 +181,7 @@
             </group>
             <group id="image" translate="label" type="text" sortOrder="120" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Image Processing Settings</label>
-                <field id="default_adapter" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="default_adapter" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Image Adapter</label>
                     <source_model>Magento\Config\Model\Config\Source\Image\Adapter</source_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Image\Adapter</backend_model>
@@ -298,11 +298,11 @@
                     <label>Disable Email Communications</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="host" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="host" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Host</label>
                     <comment>For Windows server only.</comment>
                 </field>
-                <field id="port" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="port" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Port (25)</label>
                     <comment>For Windows server only.</comment>
                 </field>
@@ -419,7 +419,7 @@
                         <![CDATA[<strong style="color:red">Warning!</strong> When using Store Code in URLs, in some cases system may not work properly if URLs without Store Codes are specified in the third-party services (e.g. PayPal etc.).]]>
                     </comment>
                 </field>
-                <field id="redirect_to_base" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="redirect_to_base" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Auto-redirect to Base URL</label>
                     <source_model>Magento\Config\Model\Config\Source\Web\Redirect</source_model>
                     <comment>I.e. redirect from http://example.com/store/ to http://www.example.com/store/</comment>
@@ -432,7 +432,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
-            <group id="unsecure" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="unsecure" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Base URLs</label>
                 <comment>Any of the fields allow fully qualified URLs that end with '/' (slash) e.g. http://example.com/magento/</comment>
                 <field id="base_url" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -440,7 +440,7 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>Specify URL or {{base_url}} placeholder.</comment>
                 </field>
-                <field id="base_link_url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="base_link_url" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Base Link URL</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>May start with {{unsecure_base_url}} placeholder.</comment>
@@ -450,13 +450,13 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>May be empty or start with {{unsecure_base_url}} placeholder.</comment>
                 </field>
-                <field id="base_media_url" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="base_media_url" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Base URL for User Media Files</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>May be empty or start with {{unsecure_base_url}} placeholder.</comment>
                 </field>
             </group>
-            <group id="secure" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="secure" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Base URLs (Secure)</label>
                 <comment>Any of the fields allow fully qualified URLs that end with '/' (slash) e.g. https://example.com/magento/</comment>
                 <field id="base_url" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -464,7 +464,7 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>Specify URL or {{base_url}}, or {{unsecure_base_url}} placeholder.</comment>
                 </field>
-                <field id="base_link_url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="base_link_url" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Secure Base Link URL</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>May start with {{secure_base_url}} or {{unsecure_base_url}} placeholder.</comment>
@@ -474,24 +474,24 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>May be empty or start with {{secure_base_url}}, or {{unsecure_base_url}} placeholder.</comment>
                 </field>
-                <field id="base_media_url" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="base_media_url" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Secure Base URL for User Media Files</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
                     <comment>May be empty or start with {{secure_base_url}}, or {{unsecure_base_url}} placeholder.</comment>
                 </field>
-                <field id="use_in_frontend" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="use_in_frontend" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Use Secure URLs on Storefront</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Secure</backend_model>
                     <comment>Enter https protocol to use Secure URLs on Storefront.</comment>
                 </field>
-                <field id="use_in_adminhtml" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="use_in_adminhtml" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Use Secure URLs in Admin</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Secure</backend_model>
                     <comment>Enter https protocol to use Secure URLs in Admin.</comment>
                 </field>
-                <field id="enable_hsts" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_hsts" translate="label comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable HTTP Strict Transport Security (HSTS)</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Secure</backend_model>
@@ -501,7 +501,7 @@
                         <field id="use_in_adminhtml">1</field>
                     </depends>
                 </field>
-                <field id="enable_upgrade_insecure" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_upgrade_insecure" translate="label comment" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Upgrade Insecure Requests</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Secure</backend_model>

--- a/app/code/Magento/Braintree/etc/adminhtml/system.xml
+++ b/app/code/Magento/Braintree/etc/adminhtml/system.xml
@@ -84,18 +84,18 @@
                             <label>Vault Title</label>
                             <config_path>payment/braintree_cc_vault/title</config_path>
                         </field>
-                        <field id="merchant_account_id" translate="label" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <field id="merchant_account_id" translate="label comment" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Merchant Account ID</label>
                             <comment>If you don't specify the merchant account to use to process a transaction, Braintree will process it using your default merchant account.</comment>
                             <config_path>payment/braintree/merchant_account_id</config_path>
                         </field>
-                        <field id="fraudprotection" translate="label" type="select" sortOrder="34" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <field id="fraudprotection" translate="label comment" type="select" sortOrder="34" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Advanced Fraud Protection</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <comment>Be sure to Enable Advanced Fraud Protection in Your Braintree Account in Settings/Processing Section</comment>
                             <config_path>payment/braintree/fraudprotection</config_path>
                         </field>
-                        <field id="kount_id" translate="label" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <field id="kount_id" translate="label comment" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Kount Merchant ID</label>
                             <comment><![CDATA[Used for direct fraud tool integration. Make sure you also contact <a href="mailto:accounts@braintreepayments.com">accounts@braintreepayments.com</a> to setup your Kount account.]]></comment>
                             <depends>
@@ -108,7 +108,7 @@
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree/debug</config_path>
                         </field>
-                        <field id="useccv" translate="label" type="select" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <field id="useccv" translate="label comment" type="select" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>CVV Verification</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <comment>Be sure to Enable AVS and/or CVV in Your Braintree Account in Settings/Processing Section.</comment>
@@ -149,7 +149,7 @@
                     <group id="braintree_paypal" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="40">
                         <label>PayPal through Braintree</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-                        <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="title" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Title</label>
                             <config_path>payment/braintree_paypal/title</config_path>
                             <comment>It is recommended to set this value to "PayPal" per store views.</comment>
@@ -187,7 +187,7 @@
                             <can_be_empty>1</can_be_empty>
                             <config_path>payment/braintree_paypal/specificcountry</config_path>
                         </field>
-                        <field id="require_billing_address" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <field id="require_billing_address" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Require Customer's Billing Address</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_paypal/require_billing_address</config_path>
@@ -203,7 +203,7 @@
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_paypal/debug</config_path>
                         </field>
-                        <field id="display_on_shopping_cart" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <field id="display_on_shopping_cart" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Display on Shopping Cart</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_paypal/display_on_shopping_cart</config_path>
@@ -239,14 +239,14 @@
                             <config_path>payment/braintree/verify_specific_countries</config_path>
                         </field>
                     </group>
-                    <group id="braintree_dynamic_descriptor" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="50">
+                    <group id="braintree_dynamic_descriptor" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="50">
                         <label>Dynamic Descriptors</label>
                         <comment><![CDATA[Dynamic descriptors are sent on a per-transaction basis and define what will appear on your customers credit card statements for a specific purchase.
                             The clearer the description of your product, the less likely customers will issue chargebacks due to confusion or non-recognition.
                             Dynamic descriptors are not enabled on all accounts by default. If you receive a validation error of 92203 or if your dynamic descriptors are not displaying as expected,
                             please <a href="mailto:support@getbraintree.com">Braintree Support</a>.]]></comment>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-                        <field id="name" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="name" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Name</label>
                             <config_path>payment/braintree/descriptor_name</config_path>
                             <comment>
@@ -254,14 +254,14 @@
                                 and the product descriptor can be up to 18, 14, or 9 characters respectively (with an * in between for a total descriptor name of 22 characters).
                             </comment>
                         </field>
-                        <field id="phone" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="phone" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Phone</label>
                             <config_path>payment/braintree/descriptor_phone</config_path>
                             <comment>
                                 The value in the phone number field of a customer's statement. Phone must be 10-14 characters and can only contain numbers, dashes, parentheses and periods.
                             </comment>
                         </field>
-                        <field id="url" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="url" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>URL</label>
                             <config_path>payment/braintree/descriptor_url</config_path>
                             <comment>

--- a/app/code/Magento/Bundle/Model/Product/Type.php
+++ b/app/code/Magento/Bundle/Model/Product/Type.php
@@ -536,12 +536,12 @@ class Type extends \Magento\Catalog\Model\Product\Type\AbstractType
 
         foreach ($selections as $selection) {
             if ($selection->getProductId() == $optionProduct->getId()) {
-                foreach ($options as &$option) {
-                    if ($option->getCode() == 'selection_qty_' . $selection->getSelectionId()) {
+                foreach ($options as $quoteItemOption) {
+                    if ($quoteItemOption->getCode() == 'selection_qty_' . $selection->getSelectionId()) {
                         if ($optionUpdateFlag) {
-                            $option->setValue(intval($option->getValue()));
+                            $quoteItemOption->setValue(intval($quoteItemOption->getValue()));
                         } else {
-                            $option->setValue($value);
+                            $quoteItemOption->setValue($value);
                         }
                     }
                 }

--- a/app/code/Magento/Captcha/Block/Captcha/DefaultCaptcha.php
+++ b/app/code/Magento/Captcha/Block/Captcha/DefaultCaptcha.php
@@ -13,7 +13,7 @@ class DefaultCaptcha extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'default.phtml';
+    protected $_template = 'Magento_Captcha::default.phtml';
 
     /**
      * @var string

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/AssignProducts.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/AssignProducts.php
@@ -13,7 +13,7 @@ class AssignProducts extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'catalog/category/edit/assign_products.phtml';
+    protected $_template = 'Magento_Catalog::catalog/category/edit/assign_products.phtml';
 
     /**
      * @var \Magento\Catalog\Block\Adminhtml\Category\Tab\Product

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -29,7 +29,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     /**
      * @var string
      */
-    protected $_template = 'catalog/category/tree.phtml';
+    protected $_template = 'Magento_Catalog::catalog/category/tree.phtml';
 
     /**
      * @var \Magento\Backend\Model\Auth\Session

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
@@ -24,7 +24,7 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Category\Tree
      *
      * @var string
      */
-    protected $_template = 'catalog/category/widget/tree.phtml';
+    protected $_template = 'Magento_Catalog::catalog/category/widget/tree.phtml';
 
     /**
      * @return void

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main.php
@@ -22,7 +22,7 @@ class Main extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/main.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/main.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Group.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Group.php
@@ -14,5 +14,5 @@ class Group extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/main/tree/group.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/main/tree/group.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Add.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Add.php
@@ -18,7 +18,7 @@ class Add extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/toolbar/add.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/toolbar/add.phtml';
 
     /**
      * @return AbstractBlock

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Main.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Main.php
@@ -20,7 +20,7 @@ class Main extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/toolbar/main.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/toolbar/main.phtml';
 
     /**
      * @return $this

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Composite/Configure.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Composite/Configure.php
@@ -22,7 +22,7 @@ class Configure extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/composite/configure.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/composite/configure.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
@@ -17,7 +17,7 @@ class Edit extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Alerts.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Alerts.php
@@ -18,7 +18,7 @@ class Alerts extends \Magento\Backend\Block\Widget\Tab
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/tab/alert.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/tab/alert.phtml';
 
     /**
      * @return $this

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Inventory.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Inventory.php
@@ -15,7 +15,7 @@ class Inventory extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/tab/inventory.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/tab/inventory.phtml';
 
     /**
      * @var \Magento\Framework\Module\Manager

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options.php
@@ -16,7 +16,7 @@ class Options extends Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options.phtml';
 
     /**
      * @return Widget

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -38,7 +38,7 @@ class Option extends Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/option.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/option.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Date.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Date.php
@@ -16,5 +16,5 @@ class Date extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Typ
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/date.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/date.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/File.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/File.php
@@ -16,5 +16,5 @@ class File extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Typ
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/file.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/file.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Select.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Select.php
@@ -16,7 +16,7 @@ class Select extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\T
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/select.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/select.phtml';
 
     /**
      * Class constructor

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Text.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Text.php
@@ -16,5 +16,5 @@ class Text extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Typ
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/text.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/text.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Price/Tier.php
@@ -13,7 +13,7 @@ class Tier extends Group\AbstractGroup
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/price/tier.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/price/tier.phtml';
 
     /**
      * Retrieve list of initial customer groups

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Websites.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Websites.php
@@ -21,7 +21,7 @@ class Websites extends \Magento\Backend\Block\Store\Switcher
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/websites.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/websites.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -23,7 +23,7 @@ class Content extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/helper/gallery.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/helper/gallery.phtml';
 
     /**
      * @var \Magento\Catalog\Model\Product\Media\Config

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Widget/Chooser/Container.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Widget/Chooser/Container.php
@@ -18,5 +18,5 @@ class Container extends Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/widget/chooser/container.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/widget/chooser/container.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
@@ -13,7 +13,7 @@ class Link extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rss/grid/link.phtml';
+    protected $_template = 'Magento_Catalog::rss/grid/link.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\UrlBuilderInterface

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
@@ -83,7 +83,7 @@ class Toolbar extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'product/list/toolbar.phtml';
+    protected $_template = 'Magento_Catalog::product/list/toolbar.phtml';
 
     /**
      * Catalog config

--- a/app/code/Magento/Catalog/Block/Product/View/Additional.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Additional.php
@@ -25,7 +25,7 @@ class Additional extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'product/view/additional.phtml';
+    protected $_template = 'Magento_Catalog::product/view/additional.phtml';
 
     /**
      * @return array

--- a/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
@@ -105,9 +105,11 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Retrieve formatted price
+     *
      * @return string
      */
-    public function getFormatedPrice()
+    public function getFormattedPrice()
     {
         if ($option = $this->getOption()) {
             return $this->_formatPrice(
@@ -118,6 +120,17 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
             );
         }
         return '';
+    }
+
+    /**
+     * @return string
+     *
+     * @deprecated
+     * @see getFormattedPrice()
+     */
+    public function getFormatedPrice()
+    {
+        return $this->getFormattedPrice();
     }
 
     /**

--- a/app/code/Magento/Catalog/Block/Product/View/Price.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Price.php
@@ -9,6 +9,8 @@
  */
 namespace Magento\Catalog\Block\Product\View;
 
+use Magento\Catalog\Model\Product;
+
 class Price extends \Magento\Framework\View\Element\Template
 {
     /**
@@ -37,7 +39,8 @@ class Price extends \Magento\Framework\View\Element\Template
      */
     public function getPrice()
     {
+        /** @var Product $product */
         $product = $this->_coreRegistry->registry('product');
-        return $product->getFormatedPrice();
+        return $product->getFormattedPrice();
     }
 }

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -1149,11 +1149,24 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     /**
      * Get formatted by currency product price
      *
-     * @return  array || double
+     * @return  array|double
+     */
+    public function getFormattedPrice()
+    {
+        return $this->getPriceModel()->getFormattedPrice($this);
+    }
+
+    /**
+     * Get formatted by currency product price
+     *
+     * @return  array|double
+     *
+     * @deprecated
+     * @see getFormattedPrice()
      */
     public function getFormatedPrice()
     {
-        return $this->getPriceModel()->getFormatedPrice($this);
+        return $this->getFormattedPrice();
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Type/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Price.php
@@ -474,14 +474,15 @@ class Price
      *
      * @param   float $qty
      * @param   Product $product
+     *
      * @return  array|float
      */
-    public function getFormatedTierPrice($qty, $product)
+    public function getFormattedTierPrice($qty, $product)
     {
         $price = $product->getTierPrice($qty);
         if (is_array($price)) {
             foreach (array_keys($price) as $index) {
-                $price[$index]['formated_price'] = $this->priceCurrency->convertAndFormat(
+                $price[$index]['formatted_price'] = $this->priceCurrency->convertAndFormat(
                     $price[$index]['website_price']
                 );
             }
@@ -493,14 +494,44 @@ class Price
     }
 
     /**
+     * Get formatted by currency tier price
+     *
+     * @param   float $qty
+     * @param   Product $product
+     *
+     * @return  array|float
+     *
+     * @deprecated
+     * @see getFormattedTierPrice()
+     */
+    public function getFormatedTierPrice($qty, $product)
+    {
+        return $this->getFormattedTierPrice($qty, $product);
+    }
+
+    /**
+     * Get formatted by currency product price
+     *
+     * @param   Product $product
+     * @return  array|float
+     */
+    public function getFormattedPrice($product)
+    {
+        return $this->priceCurrency->format($product->getFinalPrice());
+    }
+
+    /**
      * Get formatted by currency product price
      *
      * @param   Product $product
      * @return  array || float
+     *
+     * @deprecated
+     * @see getFormattedPrice()
      */
     public function getFormatedPrice($product)
     {
-        return $this->priceCurrency->format($product->getFinalPrice());
+        return $this->getFormattedPrice($product);
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductActionGroup.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+
+    <!--Fill main fields in create product form with no weight, useful for virtual and downloadable products -->
+    <actionGroup name="fillMainProductFormNoWeight">
+        <arguments>
+            <argument name="product" defaultValue="DownloadableProduct"/>
+        </arguments>
+        <fillField selector="{{AdminProductFormSection.productName}}" userInput="{{product.name}}" stepKey="fillProductName"/>
+        <fillField selector="{{AdminProductFormSection.productSku}}" userInput="{{product.sku}}" stepKey="fillProductSku"/>
+        <fillField selector="{{AdminProductFormSection.productPrice}}" userInput="{{product.price}}" stepKey="fillProductPrice"/>
+        <fillField selector="{{AdminProductFormSection.productQuantity}}" userInput="{{product.quantity}}" stepKey="fillProductQty"/>
+        <selectOption selector="{{AdminProductFormSection.productStockStatus}}" userInput="{{product.status}}" stepKey="selectStockStatus"/>
+        <selectOption selector="{{AdminProductFormSection.productWeightSelect}}" userInput="This item has no weight" stepKey="selectWeight"/>
+    </actionGroup>
+
+    <!--Save product and see success message-->
+    <actionGroup name="saveProductForm">
+        <click selector="{{AdminProductFormActionSection.saveButton}}" stepKey="clickSaveProduct"/>
+        <see selector="{{AdminProductMessagesSection.successMessage}}" userInput="You saved the product." stepKey="seeSaveConfirmation"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeSetActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeSetActionGroup.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssignAttributeToGroup">
+        <arguments>
+            <argument name="group" type="string"/>
+            <argument name="attribute" type="string"/>
+        </arguments>
+        <conditionalClick selector="{{AdminProductAttributeSetEditSection.attributeGroupExtender(group)}}" dependentSelector="{{AdminProductAttributeSetEditSection.attributeGroupCollapsed(group)}}" visible="true" stepKey="extendGroup"/>
+        <waitForPageLoad stepKey="waitForPageLoad1"/>
+        <dragAndDrop selector1="{{AdminProductAttributeSetEditSection.unassignedAttribute(attribute)}}" selector2="{{AdminProductAttributeSetEditSection.lineItemAttributeGroup(group, '1')}}" stepKey="dragAndDropToGroupProductDetails"/>
+        <waitForPageLoad stepKey="waitForPageLoad2"/>
+        <see userInput="{{attribute}}" selector="{{AdminProductAttributeSetEditSection.groupTree}}" stepKey="seeAttributeInGroup"/>
+    </actionGroup>
+    <actionGroup name="UnassignAttributeFromGroup">
+        <arguments>
+            <argument name="group" type="string"/>
+            <argument name="attribute" type="string"/>
+        </arguments>
+        <conditionalClick selector="{{AdminProductAttributeSetEditSection.attributeGroupExtender(group)}}" dependentSelector="{{AdminProductAttributeSetEditSection.attributeGroupCollapsed(group)}}" visible="true" stepKey="extendGroup"/>
+        <waitForPageLoad stepKey="waitForPageLoad1"/>
+        <dragAndDrop selector1="{{AdminProductAttributeSetEditSection.assignedAttribute(attribute)}}" selector2="{{AdminProductAttributeSetEditSection.lineItemUnassignedAttribute('1')}}" stepKey="dragAndDropToUnassigned"/>
+        <waitForPageLoad stepKey="waitForPageLoad2"/>
+        <see userInput="{{attribute}}" selector="{{AdminProductAttributeSetEditSection.unassignedAttributesTree}}" stepKey="seeAttributeInUnassigned"/>
+    </actionGroup>
+    <actionGroup name="SaveAttributeSet">
+        <click selector="{{AdminProductAttributeSetActionSection.save}}" stepKey="clickSave"/>
+        <see userInput="You saved the attribute set" selector="{{AdminMessagesSection.success}}" stepKey="successMessage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminResetProductGridToDefaultViewActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminResetProductGridToDefaultViewActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <!--Reset the product grid to the default view-->
+    <actionGroup name="AdminResetProductGridToDefaultViewActionGroup">
+        <conditionalClick selector="{{AdminProductGridFilterSection.clearFilters}}" dependentSelector="{{AdminProductGridFilterSection.clearFilters}}" visible="true" stepKey="clickClearFilters"/>
+        <click selector="{{AdminProductGridFilterSection.viewDropdown}}" stepKey="openViewBookmarksTab"/>
+        <waitForElementVisible selector="{{AdminProductGridFilterSection.viewBookmark('Default View')}}" time="10" stepKey="waitForViewBookmarkElementVisible"/>
+        <click selector="{{AdminProductGridFilterSection.viewBookmark('Default View')}}" stepKey="resetToDefaultGridView"/>
+        <see selector="{{AdminProductGridFilterSection.viewDropdown}}" userInput="Default View" stepKey="seeDefaultViewSelected"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckAttributeInAdditionalInformationTabActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckAttributeInAdditionalInformationTabActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="CheckAttributeInAdditionalInformationTabActionGroup">
+        <arguments>
+            <argument name="attributeLabel" type="string"/>
+            <argument name="attributeValue" type="string"/>
+        </arguments>
+        <click selector="{{StorefrontProductAdditionalInformationSection.additionalInfoTab}}" stepKey="clickTab"/>
+        <see userInput="{{attributeLabel}}" selector=" {{StorefrontProductAdditionalInformationSection.attributeLabel}}" stepKey="seeAttributeLabel"/>
+        <see userInput="{{attributeValue}}" selector="{{StorefrontProductAdditionalInformationSection.attributeValue}}" stepKey="seeAttributeValue"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckAttributeNotInAdditionalInformationTabActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckAttributeNotInAdditionalInformationTabActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="CheckAttributeNotInAdditionalInformationTabActionGroup">
+        <arguments>
+            <argument name="attributeLabel" type="string"/>
+        </arguments>
+        <conditionalClick selector="{{StorefrontProductAdditionalInformationSection.additionalInfoTab}}" dependentSelector="{{StorefrontProductAdditionalInformationSection.additionalInfoTab}}" visible="true" stepKey="clickTab"/>
+        <dontSee userInput="{{attributeLabel}}" selector="{{StorefrontProductAdditionalInformationSection.additionalInfoContainer}}" stepKey="dontSeeAttributeLabel"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CreateAttributeSetActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CreateAttributeSetActionGroup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <!-- Create a new attribute set -->
+    <actionGroup name="CreateAttributeSetActionGroup">
+        <arguments>
+            <argument name="nameLabel" type="string"/>
+            <argument name="basedOn" defaultValue="Default" type="string"/>
+        </arguments>
+        <amOnPage url="{{AdminProductAttributeSetGridPage.url}}" stepKey="goToAttributeSets"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <click selector="{{AdminProductAttributeSetGridSection.addAttributeSetBtn}}" stepKey="clickAddAttributeSet"/>
+        <fillField selector="{{AdminProductAttributeSetSection.name}}" userInput="{{nameLabel}}" stepKey="fillName"/>
+        <selectOption selector="{{AdminProductAttributeSetSection.basedOn}}" userInput="{{basedOn}}" stepKey="selectDefaultSet"/>
+        <click selector="{{AdminProductAttributeSetSection.save}}" stepKey="clickSave"/>
+        <see userInput="You saved the attribute set." selector="{{AdminMessagesSection.success}}" stepKey="waitSuccessMessage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CreateNewGroupInAttributeSetActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CreateNewGroupInAttributeSetActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="CreateNewGroupInAttributeSetActionGroup">
+        <arguments>
+            <argument name="groupName" type="string" defaultValue="TestGroupName"/>
+        </arguments>
+        <click selector="{{AdminProductAttributeSetSection.addNewGroupBtn}}" stepKey="clickAddNewGroup"/>
+        <waitForElementVisible selector="{{AdminPromptModalSection.promptField}}" stepKey="waitModalWindow"/>
+        <fillField selector="{{AdminPromptModalSection.promptField}}" userInput="{{groupName}}" stepKey="fillNewGroupName"/>
+        <click selector="{{AdminPromptModalSection.modalOk}}" stepKey="clickOkInModal"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteAttributeSetActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteAttributeSetActionGroup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <!-- Delete attribute set -->
+    <actionGroup name="DeleteAttributeSetActionGroup">
+        <arguments>
+            <argument name="name" type="string"/>
+        </arguments>
+        <amOnPage url="{{AdminProductAttributeSetGridPage.url}}" stepKey="goToAttributeSets"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <fillField selector="{{AdminProductAttributeSetGridSection.attributeSetNameFilter}}" userInput="{{name}}" stepKey="filterByName"/>
+        <click selector="{{AdminProductAttributeSetGridSection.applyFilterButton}}" stepKey="clickSearch"/>
+        <click selector="{{AdminProductAttributeSetGridSection.attributeSetRowByIndex('1')}}" stepKey="clickFirstRow"/>
+        <waitForPageLoad stepKey="waitForPageLoad2"/>
+        <click selector="{{AdminProductAttributeSetSection.deleteBtn}}" stepKey="clickDelete"/>
+        <click selector="{{AdminConfirmationModalSection.ok}}" stepKey="confirmDelete"/>
+        <waitForPageLoad stepKey="waitForPageLoad3"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeData.xml
@@ -33,7 +33,7 @@
         <requiredEntity type="FrontendLabel">ProductAttributeFrontendLabel</requiredEntity>
     </entity>
     <entity name="productAttributeWithDropdownTwoOptions" type="ProductAttribute">
-        <data key="attribute_code">testattribute</data>
+        <data key="attribute_code" unique="suffix">testattribute</data>
         <data key="frontend_input">select</data>
         <data key="scope">global</data>
         <data key="is_required">false</data>

--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
@@ -123,17 +123,6 @@
         <data key="status">1</data>
         <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
     </entity>
-    <entity name="VirtualProduct" type="product">
-        <data key="sku" unique="suffix">virtualproduct</data>
-        <data key="type_id">virtual</data>
-        <data key="attribute_set_id">4</data>
-        <data key="name" unique="suffix">VirtualProduct</data>
-        <data key="price">99.99</data>
-        <data key="quantity">250</data>
-        <data key="weight">0</data>
-        <data key="status">1</data>
-        <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
-    </entity>
     <entity name="SimpleProductWithNewFromDate" type="product">
         <data key="sku" unique="suffix">SimpleProduct</data>
         <data key="type_id">simple</data>
@@ -162,5 +151,19 @@
         <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
         <requiredEntity type="media_gallery_entries">ProductAttributeMediaGalleryEntryMagentoLogo</requiredEntity>
         <requiredEntity type="custom_attribute_array">CustomAttributeCategoryIds</requiredEntity>
+    </entity>
+    <entity name="ApiProductWithDescription" type="product">
+        <data key="sku" unique="suffix">api-simple-product</data>
+        <data key="type_id">simple</data>
+        <data key="attribute_set_id">4</data>
+        <data key="visibility">4</data>
+        <data key="name" unique="suffix">Api Simple Product</data>
+        <data key="price">123.00</data>
+        <data key="urlKey" unique="suffix">api-simple-product</data>
+        <data key="status">1</data>
+        <data key="quantity">100</data>
+        <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
+        <requiredEntity type="custom_attribute_array">ApiProductDescription</requiredEntity>
+        <requiredEntity type="custom_attribute_array">ApiProductShortDescription</requiredEntity>
     </entity>
 </entities>

--- a/app/code/Magento/Catalog/Test/Mftf/Page/AdminProductAttributeSetEditPage.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Page/AdminProductAttributeSetEditPage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
+    <page name="AdminProductAttributeSetEditPage" url="catalog/product_set/edit/id/{{var1}}" area="admin" module="Magento_Catalog" parameterized="true">
+        <section name="AdminProductAttributeSetEditSection"/>
+        <section name="AdminProductAttributeSetActionSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Catalog/Test/Mftf/Page/AdminProductCreatePage.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Page/AdminProductCreatePage.xml
@@ -16,5 +16,6 @@
         <section name="AdminProductMessagesSection"/>
         <section name="AdminMessagesSection"/>
         <section name="AdminProductCustomizableOptionsSection" />
+        <section name="AdminProductFormAdvancedPricingSection"/>
     </page>
 </pages>

--- a/app/code/Magento/Catalog/Test/Mftf/Page/StorefrontProductPage.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Page/StorefrontProductPage.xml
@@ -8,7 +8,8 @@
 
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
-    <page name="StorefrontProductPage" url="/{{var1}}.html" area="storefront" module="Category" parameterized="true">
+    <page name="StorefrontProductPage" url="/{{var1}}.html" area="storefront" module="Magento_Category" parameterized="true">
         <section name="StorefrontProductPageSection"/>
+        <section name="StorefrontProductAdditionalInformationSection"/>
     </page>
 </pages>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetActionSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetActionSection.xml
@@ -5,12 +5,12 @@
   * See COPYING.txt for license details.
   */
 -->
+
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
-    <section name="StorefrontHeaderSection">
-        <element name="storeViewSwitcher" type="button" selector="#switcher-language-trigger"/>
-        <element name="storeViewDropdown" type="button" selector="ul.switcher-dropdown"/>
-        <element name="storeViewOption" type="button" selector="li.view-{{var1}}>a" parameterized="true"/>
-        <element name="mainTitle" type="text" selector="#maincontent .page-title"/>
+    <section name="AdminProductAttributeSetActionSection">
+        <element name="save" type="button" selector="button[title='Save']" timeout="30"/>
+        <element name="reset" type="button" selector="button[title='Reset']" timeout="30"/>
+        <element name="back" type="button" selector="button[title='Back']" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetEditSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetEditSection.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
+    <section name="AdminProductAttributeSetEditSection">
+        <!-- Groups Column -->
+        <element name="groupTree" type="block" selector="#tree-div1"/>
+        <element name="attributeGroup" type="text" selector="//*[@id='tree-div1']//span[text()='{{groupName}}']" parameterized="true"/>
+        <element name="attributeGroupExtender" type="button" selector="//*[@id='tree-div1']//span[text()='{{groupName}}']" parameterized="true"/>
+        <element name="attributeGroupCollapsed" type="button" selector="//*[@id='tree-div1']//span[text()='{{groupName}}']/parent::*/parent::*[contains(@class, 'collapsed')]" parameterized="true"/>
+        <element name="assignedAttribute" type="text" selector="//*[@id='tree-div1']//span[text()='{{attributeName}}']" parameterized="true"/>
+        <element name="lineItemYthAttributeGroup" type="text" selector="//*[@id='tree-div1']/ul/div/li[{{y}}]//li[{{x}}]" parameterized="true"/>
+        <element name="lineItemAttributeGroup" type="text" selector="//*[@id='tree-div1']//span[text()='{{groupName}}']/parent::*/parent::*/parent::*//li[{{x}}]//a/span" parameterized="true"/>
+        <!-- Unassigned Attributes Column -->
+        <element name="unassignedAttributesTree" type="block" selector="#tree-div2"/>
+        <element name="unassignedAttribute" type="text" selector="//*[@id='tree-div2']//span[text()='{{attributeName}}']" parameterized="true"/>
+        <element name="lineItemUnassignedAttribute" type="text" selector="//*[@id='tree-div2']//li[{{x}}]//a/span" parameterized="true"/>
+    </section>
+</sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetGridSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetGridSection.xml
@@ -10,5 +10,9 @@
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
     <section name="AdminProductAttributeSetGridSection">
         <element name="attributeSetName" type="text" selector="//td[contains(text(), '{{var1}}')]" parameterized="true"/>
+        <element name="attributeSetNameFilter" type="input" selector="#setGrid_filter_set_name"/>
+        <element name="applyFilterButton" type="button" selector="#setGrid [data-action='grid-filter-apply']" timeout="30"/>
+        <element name="attributeSetRowByIndex" type="block" selector="#setGrid_table tbody tr:nth-of-type({{var1}})" parameterized="true"/>
+        <element name="addAttributeSetBtn" type="button" selector="button.add-set" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductAttributeSetSection.xml
@@ -9,6 +9,11 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
     <section name="AdminProductAttributeSetSection">
-        <element name="save" type="button" selector="button[title='Save']" />
+        <element name="save" type="button" selector="button[title='Save']" timeout="30"/>
+        <element name="deleteBtn" type="button" selector="button[title='Delete']" timeout="30"/>
+        <element name="attribute" type="button" selector="//span[text()='{{var1}}']" parameterized="true"/>
+        <element name="addNewGroupBtn" type="button" selector="button.add" timeout="30"/>
+        <element name="name" type="input" selector="#attribute_set_name"/>
+        <element name="basedOn" type="select" selector="#skeleton_set"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormAdvancedPricingSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormAdvancedPricingSection.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
+    <section name="AdminProductFormAdvancedPricingSection">
+        <element name="customerGroupPriceAddButton" type="button" selector="[data-action='add_new_row']" timeout="30"/>
+        <element name="customerGroupPriceDeleteButton" type="button" selector="[data-action='remove_row']" timeout="30"/>
+        <element name="advancedPricingCloseButton" type="button" selector=".product_form_product_form_advanced_pricing_modal button.action-close" timeout="30"/>
+        <element name="productTierPriceWebsiteSelect" type="select" selector="[name='product[tier_price][{{var1}}][website_id]']" parameterized="true"/>
+        <element name="productTierPriceCustGroupSelect" type="select" selector="[name='product[tier_price][{{var1}}][cust_group]']" parameterized="true"/>
+        <element name="productTierPriceQtyInput" type="input" selector="[name='product[tier_price][{{var1}}][price_qty]']" parameterized="true"/>
+        <element name="productTierPriceValueTypeSelect" type="select" selector="[name='product[tier_price][{{var1}}][value_type]']" parameterized="true"/>
+        <element name="productTierPriceFixedPriceInput" type="input" selector="[name='product[tier_price][{{var1}}][price]']" parameterized="true"/>
+        <element name="productTierPricePercentageValuePriceInput" type="input" selector="[name='product[tier_price][{{var1}}][percentage_value]']" parameterized="true"/>
+        <element name="specialPrice" type="input" selector="input[name='product[special_price]']"/>
+        <element name="doneButton" type="button" selector=".product_form_product_form_advanced_pricing_modal button.action-primary" timeout="5"/>
+        <element name="save" type="button" selector="#save-button"/>
+    </section>
+</sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormSection.xml
@@ -9,10 +9,14 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
     <section name="AdminProductFormSection">
+        <element name="attributeSet" type="select" selector="div[data-index='attribute_set_id'] .admin__field-control"/>
+        <element name="attributeSetFilter" type="input" selector="div[data-index='attribute_set_id'] .admin__field-control input"/>
+        <element name="attributeSetFilterResult" type="input" selector="div[data-index='attribute_set_id'] .action-menu-item._last" timeout="30"/>
         <element name="productName" type="input" selector=".admin__field[data-index=name] input"/>
         <element name="productSku" type="input" selector=".admin__field[data-index=sku] input"/>
         <element name="productStatus" type="checkbox" selector="input[name='product[status]']"/>
         <element name="productPrice" type="input" selector=".admin__field[data-index=price] input"/>
+        <element name="advancedPricingLink" type="button" selector="button[data-index='advanced_pricing_button']"/>
         <element name="categoriesDropdown" type="multiselect" selector="div[data-index='category_ids']"/>
         <element name="productQuantity" type="input" selector=".admin__field[data-index=qty] input"/>
         <element name="productStockStatus" type="select" selector="select[name='product[quantity_and_stock_status][is_in_stock]']"/>
@@ -22,6 +26,9 @@
         <element name="validationErrorLabel" type="text" selector="//label[@class='admin__field-error']"/>
         <element name="visibility" type="select" selector="//select[@name='product[visibility]']"/>
         <element name="visibilityUseDefault" type="checkbox" selector="//input[@name='use_default[visibility]']"/>
+        <element name="divByDataIndex" type="input" selector="div[data-index='{{var}}']" parameterized="true"/>
+        <element name="attributeSetSearchCount" type="text" selector="div[data-index='attribute_set_id'] .admin__action-multiselect-search-count"/>
+        <element name="attributeLabelByText" type="text" selector="//*[@class='admin__field']//span[text()='{{attributeLabel}}']" parameterized="true"/>
     </section>
     <section name="ProductInWebsitesSection">
         <element name="sectionHeader" type="button" selector="div[data-index='websites']" timeout="30"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductGridFilterSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductGridFilterSection.xml
@@ -17,5 +17,7 @@
         <element name="applyFilters" type="button" selector="button[data-action='grid-filter-apply']" timeout="30"/>
         <element name="newFromDateFilter" type="input" selector="input.admin__control-text[name='news_from_date[from]']"/>
         <element name="skuFilter" type="input" selector="input.admin__control-text[name='sku']"/>
+        <element name="viewBookmark" type="button" selector="//div[contains(@class, 'admin__data-grid-action-bookmarks')]/ul/li/div/a[text() = '{{label}}']" parameterized="true" timeout="30"/>
+        <element name="viewDropdown" type="button" selector=".admin__data-grid-action-bookmarks button.admin__action-dropdown"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductGridSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductGridSection.xml
@@ -23,5 +23,6 @@
         <element name="productNameInNameColumn" type="input" selector="//td[4]/div[@class='data-grid-cell-content']"/>
         <element name="checkbox" type="checkbox" selector="//div[contains(text(),'{{product}}')]/ancestor::tr[@class='data-row']//input[@class='admin__control-checkbox']" parameterized="true" />
         <element name="bulkActionOption" type="button" selector="//div[contains(@class,'admin__data-grid-header-row') and contains(@class, 'row')]//div[contains(@class, 'action-select-wrap')]//ul/li/span[text() = '{{label}}']" parameterized="true"/>
+        <element name="productGridNameProduct" type="input" selector="//tbody//tr//td//div[contains(., '{{var1}}')]" parameterized="true" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontCategoryProductSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontCategoryProductSection.xml
@@ -20,5 +20,9 @@
         <element name="ProductInfoByName" type="text" selector="//main//li[.//a[contains(text(), '{{var1}}')]]//div[@class='product-item-info']" parameterized="true"/>
         <element name="ProductAddToCompareByName" type="text" selector="//main//li[.//a[contains(text(), '{{var1}}')]]//a[contains(@class, 'tocompare')]" parameterized="true"/>
         <element name="ProductImageByNameAndSrc" type="text" selector="//main//li[.//a[contains(text(), '{{var1}}')]]//img[contains(@src, '{{src}}')]" parameterized="true"/>
+        <element name="productPriceFinal" type="text" selector="//span[@data-price-type='finalPrice']//span[@class='price'][contains(.,'{{var1}}')]" parameterized="true"/>
+        <element name="productPriceOld" type="text" selector="//span[@data-price-type='oldPrice']//span[@class='price'][contains(., '{{var1}}')]" parameterized="true"/>
+        <element name="productPriceLabel" type="text" selector="//span[@class='price-label'][contains(text(),'{{var1}}')]" parameterized="true"/>
+        <element name="productPriceLinkAfterLabel" type="text" selector="//span[@class='price-label'][contains(text(),'{{var1}}')]/following::span[contains(text(), '{{var2}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontProductAdditionalInformationSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontProductAdditionalInformationSection.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
+    <section name="StorefrontProductAdditionalInformationSection">
+        <element name="additionalInfoTab" type="button" selector="#tab-label-additional-title"/>
+        <element name="additionalInfoContainer" type="block" selector="#additional"/>
+        <element name="attributeLabel" type="text" selector="#product-attribute-specs-table .col.label"/>
+        <element name="attributeValue" type="text" selector="#product-attribute-specs-table .col.data"/>
+    </section>
+</sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontProductInfoMainSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontProductInfoMainSection.xml
@@ -13,6 +13,7 @@
         <element name="productName" type="text" selector=".base"/>
         <element name="productSku" type="text" selector=".product.attribute.sku>.value"/>
         <element name="productPrice" type="text" selector=".price"/>
+        <element name="qty" type="input" selector="#qty"/>
         <element name="productStockStatus" type="text" selector=".stock[title=Availability]>span"/>
         <element name="productDescription" type="text" selector="#description .value"/>
         <element name="productImageSrc" type="text" selector="//*[@id='maincontent']//div[@class='gallery-placeholder']//img[contains(@src, '{{src}}')]" parameterized="true"/>
@@ -49,5 +50,10 @@
         <element name="productAddToCompare" type="button" selector="a.action.tocompare"/>
         <element name="productOptionDropDownTitle" type="text" selector="//label[contains(.,'{{var1}}')]" parameterized="true"/>
         <element name="productOptionDropDownOptionTitle" type="text" selector="//label[contains(.,'{{var1}}')]/../div[@class='control']//select//option[contains(.,'{{var2}}')]" parameterized="true"/>
+
+        <!-- Tier price selectors -->
+        <element name="productTierPriceByForTextLabel" type="text" selector="//ul[contains(@class, 'prices-tier')]//li[{{var1}}][contains(text(),'Buy {{var2}} for')]" parameterized="true"/>
+        <element name="productTierPriceAmount" type="text" selector="//ul[contains(@class, 'prices-tier')]//li[{{var1}}]//span[contains(text(), '{{var2}}')]" parameterized="true"/>
+        <element name="productTierPriceSavePercentageAmount" type="text" selector="//ul[contains(@class, 'prices-tier')]//li[{{var1}}]//span[contains(@class, 'percent')][contains(text(), '{{var2}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminApplyTierPriceToProductTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminApplyTierPriceToProductTest.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="AdminApplyTierPriceToProductTest">
+        <annotations>
+            <features value="Apply tier price to a product"/>
+            <title value="You should be able to apply tier price to a product."/>
+            <description value="You should be able to apply tier price to a product."/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="MAGETWO-76312"/>
+            <group value="product"/>
+        </annotations>
+        <before>
+            <createData entity="Simple_US_Customer" stepKey="createSimpleUSCustomer">
+                <field key="group_id">1</field>
+            </createData>
+            <createData entity="_defaultCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createSimpleProduct">
+                <requiredEntity createDataKey="createCategory"/>
+                <field key="price">100</field>
+            </createData>
+        </before>
+        <after>
+            <deleteData createDataKey="createSimpleUSCustomer" stepKey="deleteCustomer"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteSimpleProduct"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex1"/>
+            <waitForPageLoad time="30" stepKey="waitForProductIndexPageLoad"/>
+            <actionGroup ref="AdminResetProductGridToDefaultViewActionGroup" stepKey="resetGridToDefaultKeywordSearch"/>
+            <actionGroup ref="logout" stepKey="logoutFromAdmin"/>
+        </after>
+        <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        <!--Case: Group Price-->
+        <actionGroup ref="SearchForProductOnBackendActionGroup" stepKey="searchForSimpleProduct">
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <actionGroup ref="OpenEditProductOnBackendActionGroup" stepKey="openEditProduct1">
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton1"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="waitForCustomerGroupPriceAddButton1"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="addCustomerGroupAllGroupsQty1PriceDiscountAnd10percent"/>
+        <fillField selector="{{AdminProductFormAdvancedPricingSection.productTierPriceQtyInput('0')}}" userInput="1" stepKey="fillProductTierPriceQtyInput1"/>
+        <selectOption selector="{{AdminProductFormAdvancedPricingSection.productTierPriceValueTypeSelect('0')}}" userInput="Discount" stepKey="selectProductTierPriceValueType1"/>
+        <fillField selector="{{AdminProductFormAdvancedPricingSection.productTierPricePercentageValuePriceInput('0')}}" userInput="10" stepKey="selectProductTierPricePriceInput"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.doneButton}}" stepKey="clickDoneButton1"/>
+        <actionGroup ref="SaveProductOnProductPageOnAdmin" stepKey="saveProduct1"/>
+        <actionGroup ref="CustomerLoginOnStorefront" stepKey="customerLogin1">
+            <argument name="customer" value="$$createSimpleUSCustomer$$" />
+        </actionGroup>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategoryPage1"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad1"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceFinal('90')}}" stepKey="assertProductFinalPriceIs90_1"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLabel('Regular Price')}}" stepKey="assertRegularPriceLabel_1"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceOld('100')}}" stepKey="assertRegularPriceAmount_1"/>
+        <amOnPage url="customer/account/logout/" stepKey="logoutCustomer1"/>
+        <waitForPageLoad  time="30" stepKey="waitForPageLoad2"/>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategoryPage2"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad3"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceFinal('90')}}" stepKey="assertProductFinalPriceIs90_2"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLabel('Regular Price')}}" stepKey="assertRegularPriceLabel_2"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceOld('100')}}" stepKey="assertRegularPriceAmount_2"/>
+        <!--Case: Tier Price for General Customer Group-->
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex2"/>
+        <waitForPageLoad time="30" stepKey="waitForProductPageToLoad1"/>
+        <actionGroup ref="OpenEditProductOnBackendActionGroup" stepKey="openEditProduct2">
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton2"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="waitForcustomerGroupPriceAddButton2"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.productTierPriceCustGroupSelect('0')}}" time="30" stepKey="waitForSelectCustomerGroupNameAttribute1"/>
+        <selectOption selector="{{AdminProductFormAdvancedPricingSection.productTierPriceCustGroupSelect('0')}}" userInput="General" stepKey="selectCustomerGroupGeneral"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.doneButton}}" stepKey="clickDoneButton2"/>
+        <actionGroup ref="SaveProductOnProductPageOnAdmin" stepKey="saveProduct2"/>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategoryPage3"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad4"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceFinal('100')}}" stepKey="assertProductFinalPriceIs100_1"/>
+        <dontSeeElement selector="{{StorefrontCategoryProductSection.productPriceLabel('Regular Price')}}" stepKey="assertRegularPriceLabel_3"/>
+        <actionGroup ref="CustomerLoginOnStorefront" stepKey="customerLogin2">
+            <argument name="customer" value="$$createSimpleUSCustomer$$" />
+        </actionGroup>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategoryPage4"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad5"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceFinal('90')}}" stepKey="assertProductFinalPriceIs90_3"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLabel('Regular Price')}}" stepKey="assertRegularPriceLabel_4"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceOld('100')}}" stepKey="assertRegularPriceAmount_3"/>
+        <!--Case: Tier Price applied if Product quantity meets Tier Price Condition-->
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex3"/>
+        <waitForPageLoad time="30" stepKey="waitForProductPageToLoad2"/>
+        <actionGroup ref="OpenEditProductOnBackendActionGroup" stepKey="openEditProduct3">
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton3"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="waitForcustomerGroupPriceAddButton3"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.productTierPriceCustGroupSelect('0')}}" stepKey="waitForSelectCustomerGroupNameAttribute2"/>
+        <selectOption selector="{{AdminProductFormAdvancedPricingSection.productTierPriceCustGroupSelect('0')}}" userInput="ALL GROUPS" stepKey="selectCustomerGroupAllGroups"/>
+        <fillField selector="{{AdminProductFormAdvancedPricingSection.productTierPriceQtyInput('0')}}" userInput="15" stepKey="fillProductTierPriceQtyInput15"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="clickToLoseFocusOnRequiredInputElement"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="addCustomerGroupAllGroupsQty20PriceDiscountAnd18percent2"/>
+        <fillField selector="{{AdminProductFormAdvancedPricingSection.productTierPriceQtyInput('1')}}" userInput="20" stepKey="fillProductTierPriceQtyInput20"/>
+        <selectOption selector="{{AdminProductFormAdvancedPricingSection.productTierPriceValueTypeSelect('1')}}" userInput="Discount" stepKey="selectProductTierPriceValueType2"/>
+        <fillField selector="{{AdminProductFormAdvancedPricingSection.productTierPricePercentageValuePriceInput('1')}}" userInput="18" stepKey="selectProductTierPricePriceInput18"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.doneButton}}" stepKey="clickDoneButton3"/>
+        <actionGroup ref="SaveProductOnProductPageOnAdmin" stepKey="saveProduct3"/>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategoryPage5"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad6"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceFinal('100')}}" stepKey="assertProductFinalPriceIs100_2"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLabel('As low as')}}" stepKey="assertAsLowAsPriceLabel_1"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLinkAfterLabel('As low as', '82')}}" stepKey="assertPriceAfterAsLowAsLabel_1"/>
+        <amOnPage url="customer/account/logout/" stepKey="logoutCustomer2"/>
+        <waitForPageLoad  time="30" stepKey="waitForPageLoad7"/>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategoryPage6"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad8"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceFinal('100')}}" stepKey="assertProductFinalPriceIs100_3"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLabel('As low as')}}" stepKey="assertAsLowAsPriceLabel_2"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.productPriceLinkAfterLabel('As low as', '82')}}" stepKey="assertPriceAfterAsLowAsLabel_2"/>
+        <amOnPage url="{{StorefrontProductPage.url($$createSimpleProduct.name$$)}}" stepKey="goToProductPage1"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad9"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceByForTextLabel('1', '15')}}" stepKey="assertProductTierPriceByForTextLabelForFirstRow1"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceByForTextLabel('2', '20')}}" stepKey="assertProductTierPriceByForTextLabelForSecondRow1"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceAmount('1', '90')}}" stepKey="assertProductTierPriceAmountForFirstRow1"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceAmount('2', '82')}}" stepKey="assertProductTierPriceAmountForSecondRow1"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceSavePercentageAmount('1', '10')}}" stepKey="assertProductTierPriceSavePercentageAmountForFirstRow1"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceSavePercentageAmount('2', '18')}}" stepKey="assertProductTierPriceSavePercentageAmountForSecondRow1"/>
+        <fillField userInput="10" selector="{{StorefrontProductInfoMainSection.qty}}" stepKey="fillProductQuantity1"/>
+        <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage">
+            <argument name="productName" value="$$createSimpleProduct.name$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontViewAndEditCartFromMiniCartActionGroup" stepKey="goToCheckoutFromMinicart"/>
+        <seeInField userInput="10" selector="{{CheckoutCartProductSection.productQuantityByName($$createSimpleProduct.name$$)}}" stepKey="seeInQtyField10"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField1"/>
+        <assertEquals message="Shopping cart should contain subtotal $1,000" stepKey="assertSubtotalField1">
+            <expectedResult type="string">$1,000.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField1</actualResult>
+        </assertEquals>
+        <fillField userInput="15" selector="{{CheckoutCartProductSection.productQuantityByName($$createSimpleProduct.name$$)}}" stepKey="fillProductQuantity2"/>
+        <click selector="{{CheckoutCartProductSection.updateShoppingCartButton}}" stepKey="clickUpdateShoppingCartButton1"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear1"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField2"/>
+        <assertEquals message="Shopping cart should contain subtotal $1,350" stepKey="assertSubtotalField2">
+            <expectedResult type="string">$1,350.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField2</actualResult>
+        </assertEquals>
+        <fillField userInput="20" selector="{{CheckoutCartProductSection.productQuantityByName($$createSimpleProduct.name$$)}}" stepKey="fillProductQuantity3"/>
+        <click selector="{{CheckoutCartProductSection.updateShoppingCartButton}}" stepKey="clickUpdateShoppingCartButton2"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear2"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField3"/>
+        <assertEquals message="Shopping cart should contain subtotal $1,640" stepKey="assertSubtotalField3">
+            <expectedResult type="string">$1,640.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField3</actualResult>
+        </assertEquals>
+        <!--Tier Price is changed in Shopping Cart and is changed on Product page if Tier Price parameters are changed in Admin-->
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex4"/>
+        <waitForPageLoad time="30" stepKey="waitForProductPageToLoa4"/>
+        <actionGroup ref="OpenEditProductOnBackendActionGroup" stepKey="openEditProduct4">
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton4"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="waitForcustomerGroupPriceAddButton4"/>
+        <fillField selector="{{AdminProductFormAdvancedPricingSection.productTierPricePercentageValuePriceInput('1')}}" userInput="25" stepKey="selectProductTierPricePercentageValue2"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.doneButton}}" stepKey="clickDoneButton4"/>
+        <actionGroup ref="SaveProductOnProductPageOnAdmin" stepKey="saveProduct4"/>
+        <amOnPage url="{{CheckoutCartPage.url}}" stepKey="goToShoppingCartPage1"/>
+        <waitForPageLoad time="30" stepKey="waitForShoppingCartPagePageLoad1"/>
+        <seeInField userInput="20" selector="{{CheckoutCartProductSection.productQuantityByName($$createSimpleProduct.name$$)}}" stepKey="seeInQtyField20"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField4"/>
+        <assertEquals message="Shopping cart should contain subtotal $1,500" stepKey="assertSubtotalField4">
+            <expectedResult type="string">$1,500.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField4</actualResult>
+        </assertEquals>
+        <grabTextFrom selector="{{CheckoutCartSummarySection.subtotal}}" stepKey="grabTextFromCheckoutCartSummarySectionSubtotal1"/>
+        <assertEquals message="Shopping cart summary section should contain subtotal $1,500" stepKey="assertSubtotalFieldFromCheckoutCartSummarySection1">
+            <expectedResult type="string">$1,500.00</expectedResult>
+            <actualResult type="variable">grabTextFromCheckoutCartSummarySectionSubtotal1</actualResult>
+        </assertEquals>
+        <conditionalClick selector="{{StorefrontMinicartSection.showCart}}" dependentSelector="{{StorefrontMinicartSection.miniCartOpened}}" visible="false" stepKey="openMiniCart1"/>
+        <waitForElementVisible selector="{{StorefrontMinicartSection.miniCartSubtotalField}}" stepKey="waitForminiCartSubtotalField1"/>
+        <grabTextFrom selector="{{StorefrontMinicartSection.miniCartSubtotalField}}" stepKey="grabTextFromMiniCartSubtotalField"/>
+        <assertEquals message="Mini shopping cart should contain subtotal $1,500" stepKey="assertSubtotalFieldFromMiniShoppingCart1">
+            <expectedResult type="string">$1,500.00</expectedResult>
+            <actualResult type="variable">grabTextFromMiniCartSubtotalField</actualResult>
+        </assertEquals>
+        <amOnPage url="{{AdminSalesConfigPage.url('#sales_msrp-link')}}" stepKey="navigateToAdminSalesConfigPageMAPTab1"/>
+        <waitForPageLoad time="30" stepKey="waitForAdminSalesConfigPageLoad1"/>
+        <uncheckOption selector="{{AdminSalesConfigSection.enableMAPUseSystemValue}}" stepKey="uncheckMAPUseSystemValue"/>
+        <selectOption selector="{{AdminSalesConfigSection.enableMAPSelect}}" userInput="Yes" stepKey="setEnableMAPYes"/>
+        <click selector="{{AdminConfigSection.saveButton}}" stepKey="saveConfig1"/>
+        <see selector="{{AdminMessagesSection.success}}" userInput="You saved the configuration." stepKey="seeConfigSuccessMessage1"/>
+        <actionGroup ref="ClearCacheActionGroup" stepKey="flushCache1"/>
+        <amOnPage url="{{CheckoutCartPage.url}}" stepKey="goToShoppingCartPage2"/>
+        <waitForPageLoad time="30" stepKey="waitForShoppingCartPagePageLoad2"/>
+        <seeInField userInput="20" selector="{{CheckoutCartProductSection.productQuantityByName($$createSimpleProduct.name$$)}}" stepKey="seeInQtyField20_2"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField5"/>
+        <assertEquals message="Shopping cart should contain subtotal $1,500" stepKey="assertSubtotalField5">
+            <expectedResult type="string">$1,500.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField5</actualResult>
+        </assertEquals>
+        <amOnPage url="{{AdminSalesConfigPage.url('#sales_msrp-link')}}" stepKey="navigateToAdminSalesConfigPageMAPTab2"/>
+        <waitForPageLoad time="30" stepKey="waitForAdminSalesConfigPageLoad2"/>
+        <selectOption selector="{{AdminSalesConfigSection.enableMAPSelect}}" userInput="No" stepKey="setEnableMAPNo"/>
+        <click selector="{{AdminConfigSection.saveButton}}" stepKey="saveConfig2"/>
+        <see selector="{{AdminMessagesSection.success}}" userInput="You saved the configuration." stepKey="seeConfigSuccessMessage2"/>
+        <actionGroup ref="ClearCacheActionGroup" stepKey="flushCache2"/>
+        <amOnPage url="{{CheckoutCartPage.url}}" stepKey="goToShoppingCartPage3"/>
+        <waitForPageLoad time="30" stepKey="waitForShoppingCartPagePageLoad3"/>
+        <seeInField userInput="20" selector="{{CheckoutCartProductSection.productQuantityByName($$createSimpleProduct.name$$)}}" stepKey="seeInQtyField20_3"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField6"/>
+        <assertEquals message="Shopping cart should contain subtotal $1,500" stepKey="assertSubtotalField6">
+            <expectedResult type="string">$1,500.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField6</actualResult>
+        </assertEquals>
+        <amOnPage url="{{StorefrontProductPage.url($$createSimpleProduct.name$$)}}" stepKey="goToProductPage2"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad10"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceByForTextLabel('1', '15')}}" stepKey="assertProductTierPriceByForTextLabelForFirstRow2"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceByForTextLabel('2', '20')}}" stepKey="assertProductTierPriceByForTextLabelForSecondRow2"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceAmount('1', '90')}}" stepKey="assertProductTierPriceAmountForFirstRow2"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceAmount('2', '75')}}" stepKey="assertProductTierPriceAmountForSecondRow2"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceSavePercentageAmount('1', '10')}}" stepKey="assertProductTierPriceSavePercentageAmountForFirstRow2"/>
+        <seeElement selector="{{StorefrontProductInfoMainSection.productTierPriceSavePercentageAmount('2', '25')}}" stepKey="assertProductTierPriceSavePercentageAmountForSecondRow2"/>
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex5"/>
+        <waitForPageLoad time="30" stepKey="waitForProductPageToLoad3"/>
+        <actionGroup ref="OpenEditProductOnBackendActionGroup" stepKey="openEditProduct5">
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton5"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceDeleteButton}}" stepKey="waitForcustomerGroupPriceDeleteButton"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceDeleteButton}}" stepKey="deleteFirstRowOfCustomerGroupPrice"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceDeleteButton}}" stepKey="deleteSecondRowOfCustomerGroupPrice"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.doneButton}}" stepKey="clickDoneButton5"/>
+        <actionGroup ref="SaveProductOnProductPageOnAdmin" stepKey="saveProduct5"/>
+        <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton6"/>
+        <waitForElement selector="{{AdminProductFormAdvancedPricingSection.customerGroupPriceAddButton}}" stepKey="waitForcustomerGroupPriceAddButton5"/>
+        <dontSeeElement selector="{{AdminProductFormAdvancedPricingSection.productTierPriceQtyInput('0')}}" stepKey="dontSeeQtyInputOfFirstRow"/>
+        <dontSeeElement selector="{{AdminProductFormAdvancedPricingSection.productTierPriceQtyInput('1')}}" stepKey="dontSeeQtyInputOfSecondRow"/>
+        <click selector="{{AdminProductFormAdvancedPricingSection.advancedPricingCloseButton}}" stepKey="closeAdvancedPricingPopup"/>
+        <waitForElementVisible selector="{{AdminProductFormSection.productPrice}}" stepKey="waitForAdminProductFormSectionProductPriceInput"/>
+        <fillField selector="{{AdminProductFormSection.productPrice}}" userInput="200" stepKey="fillProductPrice200"/>
+        <click selector="{{AdminProductFormActionSection.saveButton}}" stepKey="clickSaveButton"/>
+        <amOnPage url="{{CheckoutCartPage.url}}" stepKey="goToShoppingCartPage4"/>
+        <waitForPageLoad time="30" stepKey="waitForShoppingCartPagePageLoad4"/>
+        <grabTextFrom selector="{{CheckoutCartProductSection.productSubtotalByName($$createSimpleProduct.name$$)}}"  stepKey="grabTextFromSubtotalField7"/>
+        <assertEquals message="Shopping cart should contain subtotal $4,000" stepKey="assertSubtotalField7">
+            <expectedResult type="string">$4,000.00</expectedResult>
+            <actualResult type="variable">grabTextFromSubtotalField7</actualResult>
+        </assertEquals>
+        <grabTextFrom selector="{{CheckoutCartSummarySection.subtotal}}" stepKey="grabTextFromCheckoutCartSummarySectionSubtotal2"/>
+        <assertEquals message="Shopping cart summary section should contain subtotal $4,000" stepKey="assertSubtotalFieldFromCheckoutCartSummarySection2">
+            <expectedResult type="string">$4,000.00</expectedResult>
+            <actualResult type="variable">grabTextFromCheckoutCartSummarySectionSubtotal2</actualResult>
+        </assertEquals>
+        <conditionalClick selector="{{StorefrontMinicartSection.showCart}}" dependentSelector="{{StorefrontMinicartSection.miniCartOpened}}" visible="false" stepKey="openMiniCart2"/>
+        <waitForElementVisible selector="{{StorefrontMinicartSection.miniCartSubtotalField}}" stepKey="waitForminiCartSubtotalField2"/>
+        <grabTextFrom selector="{{StorefrontMinicartSection.miniCartSubtotalField}}" stepKey="grabTextFromMiniCartSubtotalField2"/>
+        <assertEquals message="Mini shopping cart should contain subtotal $4,000" stepKey="assertSubtotalFieldFromMiniShoppingCart2">
+            <expectedResult type="string">$4,000.00</expectedResult>
+            <actualResult type="variable">grabTextFromMiniCartSubtotalField2</actualResult>
+        </assertEquals>
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminAssignProductAttributeToAttributeSetTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminAssignProductAttributeToAttributeSetTest.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="AdminAssignProductAttributeToAttributeSetTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="Add/Update attribute set"/>
+            <title value="Admin should be able to assign attributes to an attribute set"/>
+            <description value="Admin should be able to assign attributes to an attribute set"/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="MAGETWO-76299"/>
+            <group value="attributeSet"/>
+        </annotations>
+        <before>
+            <createData entity="productAttributeWithDropdownTwoOptions" stepKey="attribute"/>
+
+            <createData entity="productAttributeOption1" stepKey="option1">
+                <requiredEntity createDataKey="attribute"/>
+            </createData>
+            <createData entity="productAttributeOption2" stepKey="option2">
+                <requiredEntity createDataKey="attribute"/>
+            </createData>
+
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <deleteData createDataKey="attribute" stepKey="deleteAttribute"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <!-- Go to default attribute set edit page -->
+        <amOnPage url="{{AdminProductAttributeSetEditPage.url(AddToDefaultSet.attributeSetId)}}" stepKey="onAttributeSetEdit"/>
+        <!-- Assert created attribute in unassigned section -->
+        <see userInput="$$attribute.attribute_code$$" selector="{{AdminProductAttributeSetEditSection.unassignedAttributesTree}}" stepKey="seeAttributeInUnassigned"/>
+        <!-- Assign attribute to a group -->
+        <actionGroup ref="AssignAttributeToGroup" stepKey="assignAttributeToGroup">
+            <argument name="group" value="Product Details"/>
+            <argument name="attribute" value="$$attribute.attribute_code$$"/>
+        </actionGroup>
+        <!-- Assert attribute in a group -->
+        <see userInput="$$attribute.attribute_code$$" selector="{{AdminProductAttributeSetEditSection.groupTree}}" stepKey="seeAttributeInGroup"/>
+        <!-- Save attribute set -->
+        <actionGroup ref="SaveAttributeSet" stepKey="SaveAttributeSet"/>
+        <!-- Go to create new product page -->
+        <amOnPage url="{{AdminProductCreatePage.url(AddToDefaultSet.attributeSetId, 'simple')}}" stepKey="navigateToNewProduct"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <!-- Assert attribute can be used in product creation -->
+        <seeElement selector="{{AdminProductFormSection.attributeLabelByText($$attribute.attribute[frontend_labels][0][label]$$)}}" stepKey="seeLabel"/>
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductCustomAttributeSet.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductCustomAttributeSet.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="AdminCreateProductCustomAttributeSet">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="Add/Update attribute set"/>
+            <title value="Admin should be able to create a simple product using a custom attribute set"/>
+            <description value="Admin should be able to create a simple product using a custom attribute set"/>
+            <severity value="AVERAGE"/>
+            <testCaseId value="MAGETWO-79284"/>
+            <group value="catalog"/>
+            <group value="attributeSet"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+
+            <!-- Create the new attribute set -->
+            <actionGroup ref="CreateAttributeSetActionGroup" stepKey="createAttributeSet">
+                <argument name="nameLabel" value="{{ProductAttributeFrontendLabel.label}}"/>
+            </actionGroup>
+            <!-- Move attributes-->
+            <dragAndDrop selector1="{{AdminProductAttributeSetSection.attribute('meta_keyword')}}" selector2="{{AdminProductAttributeSetSection.attribute('manufacturer')}}" stepKey="unassign1"/>
+            <actionGroup ref="CreateNewGroupInAttributeSetActionGroup" stepKey="createNewGroup"/>
+            <dragAndDrop selector1="{{AdminProductAttributeSetSection.attribute('manufacturer')}}" selector2="{{AdminProductAttributeSetSection.attribute('TestGroupName')}}" stepKey="assignManufacturer"/>
+            <click selector="{{AdminProductAttributeSetSection.save}}" stepKey="clickSave2"/>
+        </before>
+
+        <after>
+            <!-- Delete the new attribute set -->
+            <actionGroup ref="DeleteAttributeSetActionGroup" stepKey="deleteAttributeSet">
+                <argument name="name" value="{{ProductAttributeFrontendLabel.label}}"/>
+            </actionGroup>
+
+            <actionGroup ref="logout" stepKey="logoutOfAdmin"/>
+        </after>
+
+        <!-- Go to new product page and see a default attribute -->
+        <amOnPage url="{{AdminProductCreatePage.url('4', 'simple')}}" stepKey="goToNewProductPage"/>
+        <waitForPageLoad stepKey="wait2"/>
+        <click selector="{{AdminProductSEOSection.sectionHeader}}" stepKey="expandSEOSection"/>
+        <seeElementInDOM selector="{{AdminProductFormSection.divByDataIndex('meta_keyword')}}" stepKey="seeMetaKeyword"/>
+        <dontSeeElementInDOM selector="{{AdminProductFormSection.divByDataIndex('testgroupname')}}" stepKey="dontSeeTestGroupName"/>
+
+        <!-- Switch from default attribute set to new attribute set -->
+        <!-- A scrollToTopOfPage is needed to hide the floating header -->
+        <scrollToTopOfPage stepKey="scrollToTop"/>
+        <click selector="{{AdminProductFormSection.attributeSet}}" stepKey="startEditAttrSet"/>
+        <fillField selector="{{AdminProductFormSection.attributeSetFilter}}" userInput="{{ProductAttributeFrontendLabel.label}}" stepKey="searchForAttrSet"/>
+        <waitForElementVisible selector="{{AdminProductFormSection.attributeSetSearchCount}}" stepKey="waitLoadOption"/>
+        <click selector="{{AdminProductFormSection.attributeSetFilterResult}}" stepKey="selectAttrSet"/>
+
+        <!-- See new attribute set -->
+        <seeElementInDOM selector="{{AdminProductFormSection.divByDataIndex('testgroupname')}}" stepKey="seeTestGroupName"/>
+        <dontSeeElementInDOM selector="{{AdminProductFormSection.divByDataIndex('meta_keyword')}}" stepKey="dontSeeMetaKeyword"/>
+
+        <!-- Finish filling the new product page -->
+        <actionGroup ref="fillMainProductFormNoWeight" stepKey="fillSimpleProductMain">
+            <argument name="product" value="_defaultProduct"/>
+        </actionGroup>
+        <actionGroup ref="saveProductForm" stepKey="saveSimpleProduct"/>
+
+        <!-- Check the storefront -->
+        <amOnPage url="{{_defaultProduct.name}}.html" stepKey="goToProductPage"/>
+        <waitForPageLoad stepKey="waitForProductPageLoad"/>
+        <seeInTitle userInput="{{_defaultProduct.name}}" stepKey="seeProductNameInTitlte"/>
+        <see userInput="{{_defaultProduct.name}}" selector="{{StorefrontProductInfoMainSection.productName}}" stepKey="assertProductName"/>
+        <see userInput="{{_defaultProduct.sku}}" selector="{{StorefrontProductInfoMainSection.productSku}}" stepKey="assertProductSku"/>
+        <see userInput="${{_defaultProduct.price}}" selector="{{StorefrontProductInfoMainSection.productPrice}}" stepKey="assertProductPrice"/>
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminUnassignProductAttributeFromAttributeSetTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminUnassignProductAttributeFromAttributeSetTest.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="AdminUnassignProductAttributeFromAttributeSetTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="Add/Update attribute set"/>
+            <title value="Assign/Unassign attributes to/from Attribute Set"/>
+            <description value="Assign/Unassign attributes to/from Attribute Set"/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="MAGETWO-76299"/>
+            <group value="catalog"/>
+            <group value="attributeSet"/>
+        </annotations>
+        <before>
+            <createData entity="productAttributeWithDropdownTwoOptions" stepKey="attribute"/>
+
+            <createData entity="productAttributeOption1" stepKey="option1">
+                <requiredEntity createDataKey="attribute"/>
+            </createData>
+            <createData entity="productAttributeOption2" stepKey="option2">
+                <requiredEntity createDataKey="attribute"/>
+            </createData>
+
+            <createData entity="AddToDefaultSet" stepKey="addToDefaultSet">
+                <requiredEntity createDataKey="attribute"/>
+            </createData>
+
+            <createData entity="ApiProductWithDescription" stepKey="product"/>
+
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <deleteData createDataKey="attribute" stepKey="deleteAttribute"/>
+            <deleteData createDataKey="product" stepKey="deleteProduct"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <!-- Assert attribute presence in storefront product additional information -->
+        <amOnPage url="/$$product.custom_attributes[url_key]$$.html" stepKey="onProductPage1"/>
+        <waitForPageLoad stepKey="waitForPageLoad1"/>
+        <actionGroup ref="CheckAttributeInAdditionalInformationTabActionGroup" stepKey="checkAttributeInMoreInformationTab">
+            <argument name="attributeLabel" value="$$attribute.attribute[frontend_labels][0][label]$$"/>
+            <argument name="attributeValue" value="$$option2.option[store_labels][0][label]$$"/>
+        </actionGroup>
+        <!-- Go to default attribute set edit page -->
+        <amOnPage url="{{AdminProductAttributeSetEditPage.url(AddToDefaultSet.attributeSetId)}}" stepKey="onAttributeSetEdit"/>
+        <waitForPageLoad stepKey="waitForPageLoad2"/>
+        <!-- Assert created attribute in a group -->
+        <see userInput="$$attribute.attribute_code$$" selector="{{AdminProductAttributeSetEditSection.groupTree}}" stepKey="seeAttributeInGroup"/>
+        <!-- Unassign attribute from group -->
+        <actionGroup ref="UnassignAttributeFromGroup" stepKey="unAssignAttributeFromGroup">
+            <argument name="group" value="Product Details"/>
+            <argument name="attribute" value="$$attribute.attribute_code$$"/>
+        </actionGroup>
+        <!-- Assert attribute in unassigned section -->
+        <see userInput="$$attribute.attribute_code$$" selector="{{AdminProductAttributeSetEditSection.unassignedAttributesTree}}" stepKey="seeAttributeInUnassigned"/>
+        <!-- Save attribute set -->
+        <actionGroup ref="SaveAttributeSet" stepKey="saveAttributeSet"/>
+        <!-- Go to create new product page -->
+        <amOnPage url="{{AdminProductCreatePage.url(AddToDefaultSet.attributeSetId, 'simple')}}" stepKey="navigateToNewProduct"/>
+        <waitForPageLoad time="30" stepKey="waitForPageLoad3"/>
+        <!-- Assert attribute not present in product creation -->
+        <dontSeeElement selector="{{AdminProductFormSection.attributeLabelByText($$attribute.attribute[frontend_labels][0][label]$$)}}" stepKey="dontSeeAttributeLabel"/>
+        <actionGroup ref="ClearCacheActionGroup" stepKey="clearCache"/>
+        <!-- Assert removed attribute not presence in storefront product additional information -->
+        <amOnPage url="/$$product.custom_attributes[url_key]$$.html" stepKey="onProductPage2"/>
+        <waitForPageLoad stepKey="waitForPageLoad4"/>
+        <actionGroup ref="CheckAttributeNotInAdditionalInformationTabActionGroup" stepKey="checkAttributeNotInMoreInformationTab">
+            <argument name="attributeLabel" value="$$attribute.attribute[frontend_labels][0][label]$$"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontProductsCompareWithEmptyAttributeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontProductsCompareWithEmptyAttributeTest.xml
@@ -37,7 +37,7 @@
         <amOnPage url="{{AdminProductAttributeSetGridPage.url}}" stepKey="amOnAttributeSetPage"/>
         <click selector="{{AdminProductAttributeSetGridSection.attributeSetName('Default')}}" stepKey="chooseDefaultAttributeSet"/>
         <waitForPageLoad stepKey="waitForAttributeSetPageLoad"/>
-        <dragAndDrop selector1="{{AdminProductAttributeUnassignedSection.productAttributeName('testattribute')}}" selector2="{{AdminProductAttributeGroupSection.folderName('Product Details')}}" stepKey="moveProductAttributeToGroup"/>
+        <dragAndDrop selector1="{{AdminProductAttributeUnassignedSection.productAttributeName('$$createProductAttribute.attribute_code$$')}}" selector2="{{AdminProductAttributeGroupSection.folderName('Product Details')}}" stepKey="moveProductAttributeToGroup"/>
         <click selector="{{AdminProductAttributeSetSection.save}}" stepKey="saveAttributeSet"/>
         <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear" />
         <seeElement selector=".message-success" stepKey="assertSuccess"/>
@@ -80,6 +80,6 @@
             <argument name="productVar" value="$$createSimpleProduct1$$"/>
         </actionGroup>
         <seeElement selector="{{StorefrontProductCompareMainSection.productAttributeByName('SKU')}}" stepKey="seeCompareAttributeSku"/>
-        <dontSeeElement selector="{{StorefrontProductCompareMainSection.productAttributeByName('testattribute')}}" stepKey="dontSeeCompareTestAttribute"/>
+        <dontSeeElement selector="{{StorefrontProductCompareMainSection.productAttributeByName('$$createProductAttribute.attribute_code$$')}}" stepKey="dontSeeCompareTestAttribute"/>
     </test>
 </tests>

--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -103,7 +103,6 @@
                 <clone_fields>1</clone_fields>
                 <clone_model>Magento\Catalog\Model\Config\CatalogClone\Media\Image</clone_model>
                 <field id="placeholder" type="image" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label></label>
                     <backend_model>Magento\Config\Model\Config\Backend\Image</backend_model>
                     <upload_dir config="system/filesystem/media" scope_info="1">catalog/product/placeholder</upload_dir>
                     <base_url type="media" scope_info="1">catalog/product/placeholder</base_url>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
@@ -13,7 +13,7 @@
 <div class="admin__field field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
   <label class="label admin__field-label">
       <?= $block->escapeHtml($_option->getTitle()) ?>
-      <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+      <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
   </label>
   <div class="admin__field-control control">
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_fileInfo = $block->getFileInfo(); ?>
 <?php $_fileExists = $_fileInfo->hasData() ? true : false; ?>
@@ -64,7 +65,7 @@ require(['prototype'], function(){
 <div class="admin__field <?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="admin__field-label label">
         <?= $block->escapeHtml($_option->getTitle()) ?>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
     <div class="admin__field-control control">
         <?php if ($_fileExists): ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
@@ -12,7 +12,7 @@
 <div class="field admin__field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="admin__field-label label">
         <?= $block->escapeHtml($_option->getTitle()) ?>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
     <div class="control admin__field-control">
         <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_FIELD): ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_optionId = $_option->getId() ?>
 <?php $class = ($_option->getIsRequire()) ? ' required' : ''; ?>
@@ -15,7 +16,7 @@
     <fieldset class="fieldset fieldset-product-options-inner<?= /* @escapeNotVerified */ $class ?>">
         <legend class="legend">
             <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
-            <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+            <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
         </legend>
         <div class="control">
             <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DATE_TIME

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_fileInfo = $block->getFileInfo(); ?>
 <?php $_fileExists = $_fileInfo->hasData(); ?>
@@ -19,7 +20,7 @@
 <div class="field file<?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="<?= /* @noEscape */ $_fileName ?>" id="<?= /* @noEscape */ $_fileName ?>-label">
         <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
     <?php if ($_fileExists): ?>
     <div class="control">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Text */ ?>
 <?php
 $_option = $block->getOption();
 $class = ($_option->getIsRequire()) ? ' required' : '';
@@ -17,7 +18,7 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
 } ?><?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="options_<?= /* @escapeNotVerified */ $_option->getId() ?>_text">
         <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
 
     <div class="control">

--- a/app/code/Magento/CatalogInventory/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogInventory/etc/adminhtml/system.xml
@@ -41,13 +41,13 @@
                     <![CDATA[Please note that these settings apply to individual items in the cart, not to the entire cart.]]>
                 </comment>
                 <label>Product Stock Options</label>
-                <field id="manage_stock" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="manage_stock" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Manage Stock</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\CatalogInventory\Model\Config\Backend\Managestock</backend_model>
                     <comment>Changing can take some time due to processing whole catalog.</comment>
                 </field>
-                <field id="backorders" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="backorders" translate="label comment" type="select" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Backorders</label>
                     <source_model>Magento\CatalogInventory\Model\Source\Backorders</source_model>
                     <backend_model>Magento\CatalogInventory\Model\Config\Backend\Backorders</backend_model>

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
@@ -27,7 +27,7 @@
                     <label>Maximum Query Length</label>
                     <validate>validate-digits</validate>
                 </field>
-                <field id="max_count_cacheable_search_terms" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="max_count_cacheable_search_terms" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Number of top search results to cache</label>
                     <comment>Number of popular search terms to be cached for faster response. Use “0” to cache all results after a term is searched for the second time.</comment>
                     <validate>validate-digits</validate>

--- a/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
@@ -51,7 +51,7 @@ class Conditions extends Template implements RendererInterface
     /**
      * @var string
      */
-    protected $_template = 'product/widget/conditions.phtml';
+    protected $_template = 'Magento_CatalogWidget::product/widget/conditions.phtml';
 
     /**
      * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/GuestCheckoutFillingShippingSectionActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/GuestCheckoutFillingShippingSectionActionGroup.xml
@@ -28,5 +28,6 @@
         <click selector="{{CheckoutShippingSection.next}}" stepKey="clickNext"/>
         <waitForElement selector="{{CheckoutPaymentSection.paymentSectionTitle}}" time="30" stepKey="waitForPaymentSectionLoaded"/>
         <seeInCurrentUrl url="{{CheckoutPage.url}}/#payment" stepKey="assertCheckoutPaymentUrl"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMask1"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenCartFromMinicartActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenCartFromMinicartActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <!-- Open the Cart from Minicart-->
+    <actionGroup name="StorefrontOpenCartFromMinicartActionGroup">
+        <waitForElement selector="{{StorefrontMinicartSection.showCart}}" stepKey="waitForShowMinicart" />
+        <waitForElement selector="{{StorefrontMinicartSection.viewAndEditCart}}" stepKey="waitForCartLink" />
+        <click selector="{{StorefrontMinicartSection.showCart}}" stepKey="clickShowMinicart" />
+        <click selector="{{StorefrontMinicartSection.viewAndEditCart}}" stepKey="clickCart" />
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontViewAndEditCartFromMiniCartActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontViewAndEditCartFromMiniCartActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontViewAndEditCartFromMiniCartActionGroup">
+        <conditionalClick selector="{{StorefrontMinicartSection.showCart}}" dependentSelector="{{StorefrontMinicartSection.miniCartOpened}}" visible="false" stepKey="openMiniCart"/>
+        <waitForElementVisible selector="{{StorefrontMinicartSection.viewAndEditCart}}" stepKey="waitForViewAndEditCartVisible"/>
+        <click selector="{{StorefrontMinicartSection.viewAndEditCart}}" stepKey="viewAndEditCart"/>
+        <seeInCurrentUrl url="checkout/cart" stepKey="seeInCurrentUrl"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Checkout/Test/Mftf/Page/CheckoutCartPage.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Page/CheckoutCartPage.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
+    <page name="CheckoutCartPage" url="/checkout/cart" area="storefront" module="Magento_Checkout">
+        <section name="CheckoutCartProductSection"/>
+        <section name="CheckoutCartSummarySection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Checkout/Test/Mftf/Page/CheckoutSuccessPage.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Page/CheckoutSuccessPage.xml
@@ -8,7 +8,8 @@
 
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
-    <page name="CheckoutSuccessPage" url="/checkout/onepage/success/" area="storefront" module="Checkout">
+    <page name="CheckoutSuccessPage" url="/checkout/onepage/success/" area="storefront" module="Magento_Checkout">
         <section name="CheckoutSuccessMainSection"/>
+        <section name="CheckoutSuccessRegisterSection"/>
     </page>
 </pages>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartProductSection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartProductSection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
+    <section name="CheckoutCartProductSection">
+        <element name="productQuantityByName" type="input" selector="//main//table[@id='shopping-cart-table']//tbody//tr[..//strong[contains(@class, 'product-item-name')]//a/text()='{{var1}}'][1]//td[contains(@class, 'qty')]//input[contains(@class, 'qty')]" parameterized="true"/>
+        <element name="productSubtotalByName" type="input" selector="//main//table[@id='shopping-cart-table']//tbody//tr[..//strong[contains(@class, 'product-item-name')]//a/text()='{{var1}}'][1]//td[contains(@class, 'subtotal')]//span[@class='price']" parameterized="true"/>
+        <element name="updateShoppingCartButton" type="button" selector="#form-validate button[type='submit'].update" timeout="30"/>
+    </section>
+</sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartSummarySection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartSummarySection.xml
@@ -5,12 +5,11 @@
   * See COPYING.txt for license details.
   */
 -->
+
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
-    <section name="StorefrontHeaderSection">
-        <element name="storeViewSwitcher" type="button" selector="#switcher-language-trigger"/>
-        <element name="storeViewDropdown" type="button" selector="ul.switcher-dropdown"/>
-        <element name="storeViewOption" type="button" selector="li.view-{{var1}}>a" parameterized="true"/>
-        <element name="mainTitle" type="text" selector="#maincontent .page-title"/>
+    <section name="CheckoutCartSummarySection">
+        <element name="subtotal" type="text" selector="#cart-totals tr.totals.sub span.price"/>
+        <element name="proceedToCheckout" type="button" selector=".action.primary.checkout span" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutSuccessMainSection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutSuccessMainSection.xml
@@ -9,10 +9,14 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
     <section name="CheckoutSuccessMainSection">
+        <element name="successTitle" type="text" selector=".page-title"/>
         <element name="success" type="text" selector="div.checkout-success"/>
         <element name="orderNumber" type="text" selector="div.checkout-success > p:nth-child(1) > span"/>
         <element name="orderNumberLink" type="text" selector="div.checkout-success > p:nth-child(1) > a"/>
         <element name="orderNumber22" type="text" selector=".order-number>strong"/>
         <element name="orderLink" type="text" selector="a[href*=order_id].order-number"/>
+        <element name="orderNumberText" type="text" selector=".checkout-success > p:nth-child(1)"/>
+        <element name="continueShoppingButton" type="button" selector=".action.primary.continue"/>
+        <element name="printLink" type="button" selector=".print"/>
     </section>
 </sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutSuccessRegisterSection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutSuccessRegisterSection.xml
@@ -5,12 +5,12 @@
   * See COPYING.txt for license details.
   */
 -->
+
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
-    <section name="StorefrontHeaderSection">
-        <element name="storeViewSwitcher" type="button" selector="#switcher-language-trigger"/>
-        <element name="storeViewDropdown" type="button" selector="ul.switcher-dropdown"/>
-        <element name="storeViewOption" type="button" selector="li.view-{{var1}}>a" parameterized="true"/>
-        <element name="mainTitle" type="text" selector="#maincontent .page-title"/>
+    <section name="CheckoutSuccessRegisterSection">
+        <element name="registerMessage" type="text" selector="#registration p:nth-child(1)"/>
+        <element name="customerEmail" type="text" selector="#registration p:nth-child(2)"/>
+        <element name="createAccountButton" type="button" selector="#registration form input[type='submit']"/>
     </section>
 </sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/StorefrontMinicartSection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/StorefrontMinicartSection.xml
@@ -22,5 +22,6 @@
         <element name="goToCheckout" type="button" selector="#top-cart-btn-checkout" timeout="30"/>
         <element name="viewAndEditCart" type="button" selector=".action.viewcart" timeout="30"/>
         <element name="miniCartItemsText" type="text" selector=".minicart-items"/>
+        <element name="miniCartSubtotalField" type="text" selector=".block-minicart .amount span.price"/>
     </section>
 </sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/CheckCheckoutSuccessPageTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/CheckCheckoutSuccessPageTest.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="CheckCheckoutSuccessPageAsRegisterCustomer">
+        <annotations>
+            <features value="Checkout"/>
+            <stories value="Success page elements are presented for placed order as Customer"/>
+            <title value="Customer Checkout"/>
+            <description value="To be sure that other elements of Success page are shown for placed order as registered Customer."/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="MAGETWO-77616"/>
+            <group value="checkout"/>
+        </annotations>
+
+        <before>
+            <createData entity="SimpleOne" stepKey="createSimpleProduct"/>
+            <createData entity="Simple_US_Customer" stepKey="createSimpleUsCustomer">
+                <field key="group_id">1</field>
+            </createData>
+        </before>
+
+        <after>
+            <!--Logout from customer account-->
+            <amOnPage url="customer/account/logout/" stepKey="logoutCustomerOne"/>
+            <waitForPageLoad stepKey="waitLogoutCustomerOne"/>
+            <actionGroup ref="logout" stepKey="logoutAdminUserAfterTest"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteProduct"/>
+            <deleteData createDataKey="createSimpleUsCustomer" stepKey="deleteCustomer"/>
+        </after>
+
+        <!--Log in to Storefront as Customer-->
+        <actionGroup ref="CustomerLoginOnStorefront" stepKey="signUpNewUser">
+            <argument name="customer" value="$$createSimpleUsCustomer$$"/>
+        </actionGroup>
+
+        <!--Go to product page-->
+        <amOnPage url="$$createSimpleProduct.custom_attributes[url_key]$$.html" stepKey="navigateToSimpleProductPage"/>
+        <waitForPageLoad stepKey="waitForCatalogPageLoad"/>
+
+        <!--Add Product to Shopping Cart-->
+        <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage">
+            <argument name="productName" value="$$createSimpleProduct.name$$"/>
+        </actionGroup>
+
+        <!--Go to Checkout-->
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="goToCheckoutFromMinicart"/>
+        <click selector="{{CheckoutShippingMethodsSection.firstShippingMethod}}" stepKey="selectFirstShippingMethod"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMask2"/>
+        <waitForElement selector="{{CheckoutShippingMethodsSection.next}}" time="30" stepKey="waitForNextButton"/>
+        <click selector="{{CheckoutShippingMethodsSection.next}}" stepKey="clickNext"/>
+        <waitForElement selector="{{CheckoutPaymentSection.paymentSectionTitle}}" time="30" stepKey="waitForPaymentSectionLoadedTest3"/>
+
+        <!--Click Place Order button-->
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear2"/>
+        <click selector="{{CheckoutPaymentSection.placeOrder}}" stepKey="clickPlaceOrder"/>
+        <see selector="{{CheckoutSuccessMainSection.successTitle}}" userInput="Thank you for your purchase!" stepKey="seeSuccessTitle"/>
+        <see selector="{{CheckoutSuccessMainSection.orderNumberText}}" userInput="Your order number is: " stepKey="seeOrderNumber"/>
+        <see selector="{{CheckoutSuccessMainSection.success}}" userInput="We'll email you an order confirmation with details and tracking info." stepKey="seeSuccessNotify"/>
+
+        <click selector="{{CheckoutSuccessMainSection.orderLink}}" stepKey="clickOrderLink"/>
+        <waitForPageLoad stepKey="waitPageOrder"/>
+        <seeInCurrentUrl url="{{OrderDetailsPage.url}}" stepKey="seeMyOrderPage"/>
+
+        <!--Go to product page-->
+        <amOnPage url="$$createSimpleProduct.custom_attributes[url_key]$$.html" stepKey="navigateToSimpleProductPage2"/>
+        <waitForPageLoad stepKey="waitForCatalogPageLoad2"/>
+
+        <!--Add Product to Shopping Cart-->
+        <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage2">
+            <argument name="productName" value="$$createSimpleProduct.name$$"/>
+        </actionGroup>
+
+        <!--Go to Checkout-->
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="goToCheckoutFromMinicart2"/>
+        <click selector="{{CheckoutShippingMethodsSection.firstShippingMethod}}" stepKey="selectFirstShippingMethod2"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMask3"/>
+        <waitForElement selector="{{CheckoutShippingMethodsSection.next}}" time="30" stepKey="waitForNextButton2"/>
+        <click selector="{{CheckoutShippingMethodsSection.next}}" stepKey="clickNext2"/>
+        <waitForElement selector="{{CheckoutPaymentSection.paymentSectionTitle}}" time="30" stepKey="waitForPaymentSectionLoadedTest4"/>
+
+        <!--Click Place Order button-->
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
+        <click selector="{{CheckoutPaymentSection.placeOrder}}" stepKey="clickPlaceOrder2"/>
+        <see selector="{{CheckoutSuccessMainSection.successTitle}}" userInput="Thank you for your purchase!" stepKey="seeSuccessTitle2"/>
+        <click selector="{{CheckoutSuccessMainSection.continueShoppingButton}}" stepKey="clickContinueShoppingButton"/>
+        <waitForPageLoad stepKey="waitHomePage"/>
+        <see userInput="Home Page" selector="{{StorefrontHeaderSection.mainTitle}}" stepKey="seeHomePageTitle"/>
+        <seeCurrentUrlEquals url="{{_ENV.MAGENTO_BASE_URL}}" stepKey="seeHomePageUrl"/>
+
+        <!--Go to product page-->
+        <amOnPage url="$$createSimpleProduct.custom_attributes[url_key]$$.html" stepKey="navigateToSimpleProductPage3"/>
+        <waitForPageLoad stepKey="waitForCatalogPageLoad3"/>
+
+        <!--Add Product to Shopping Cart-->
+        <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage3">
+            <argument name="productName" value="$$createSimpleProduct.name$$"/>
+        </actionGroup>
+
+        <!--Go to Checkout-->
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="goToCheckoutFromMinicart3"/>
+        <click selector="{{CheckoutShippingMethodsSection.firstShippingMethod}}" stepKey="selectFirstShippingMethod3"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMask4"/>
+        <waitForElement selector="{{CheckoutShippingMethodsSection.next}}" time="30" stepKey="waitForNextButton3"/>
+        <click selector="{{CheckoutShippingMethodsSection.next}}" stepKey="clickNext3"/>
+        <waitForElement selector="{{CheckoutPaymentSection.paymentSectionTitle}}" time="30" stepKey="waitForPaymentSectionLoadedTest5"/>
+
+        <!--Click Place Order button-->
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear3"/>
+        <click selector="{{CheckoutPaymentSection.placeOrder}}" stepKey="clickPlaceOrder3"/>
+        <see selector="{{CheckoutSuccessMainSection.successTitle}}" userInput="Thank you for your purchase!" stepKey="seeSuccessTitle3"/>
+
+        <!--Check "Print Receipt" button is presented (desktop only)-->
+        <seeElement selector="{{CheckoutSuccessMainSection.printLink}}" stepKey="seeVisiblePrint"/>
+        <resizeWindow width="600" height="800" stepKey="resizeWindow"/>
+        <waitForElementNotVisible selector="{{CheckoutSuccessMainSection.printLink}}" stepKey="waitInvisiblePrint"/>
+        <dontSeeElement selector="{{CheckoutSuccessMainSection.printLink}}" stepKey="seeInvisiblePrint"/>
+        <resizeWindow width="1360" height="1020" stepKey="maximizeWindowKey1"/>
+        <waitForElementVisible selector="{{CheckoutSuccessMainSection.printLink}}" stepKey="waitVisiblePrint"/>
+        <seeElement selector="{{CheckoutSuccessMainSection.printLink}}" stepKey="seeVisiblePrint2" />
+
+        <!--See print page-->
+        <click selector="{{CheckoutSuccessMainSection.printLink}}" stepKey="clickPrintLink"/>
+        <waitForPageLoad stepKey="waitPrintPage"/>
+        <switchToWindow stepKey="switchToWindow"/>
+        <switchToNextTab stepKey="switchToTab"/>
+        <seeInCurrentUrl url="sales/order/print/order_id" stepKey="seePrintPage"/>
+        <seeElement selector="{{StorefrontCustomerOrderViewSection.orderTitle}}" stepKey="seeOrderTitleOnPrint"/>
+        <switchToWindow stepKey="switchToWindow2"/>
+    </test>
+    <test name="CheckCheckoutSuccessPageAsGuest">
+        <annotations>
+            <features value="Checkout"/>
+            <stories value="Success page elements are presented for placed order as Guest"/>
+            <title value="Customer Checkout"/>
+            <description value="To be sure that other elements of Success page are presented for placed order as Guest."/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="MAGETWO-77614"/>
+            <group value="checkout"/>
+        </annotations>
+
+        <before>
+            <createData entity="SimpleOne" stepKey="createSimpleProduct"/>
+        </before>
+
+        <after>
+            <amOnPage url="admin/admin/auth/logout/" stepKey="amOnLogoutPage"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteProduct"/>
+        </after>
+
+        <!--Go to product page-->
+        <amOnPage url="$$createSimpleProduct.custom_attributes[url_key]$$.html" stepKey="navigateToSimpleProductPage"/>
+        <waitForPageLoad stepKey="waitForCatalogPageLoad"/>
+
+        <!--Add Product to Shopping Cart-->
+        <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage">
+            <argument name="productName" value="$$createSimpleProduct.name$$"/>
+        </actionGroup>
+
+        <!--Go to Checkout-->
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="goToCheckoutFromMinicart"/>
+
+        <actionGroup ref="GuestCheckoutFillingShippingSectionActionGroup" stepKey="guestCheckoutFillingShippingSection">
+            <argument name="customerVar" value="CustomerEntityOne" />
+            <argument name="customerAddressVar" value="CustomerAddressSimple" />
+        </actionGroup>
+
+        <!--Click Place Order button-->
+        <click selector="{{CheckoutPaymentSection.placeOrder}}" stepKey="clickPlaceOrder"/>
+        <see selector="{{CheckoutSuccessMainSection.successTitle}}" userInput="Thank you for your purchase!" stepKey="waitForLoadSuccessPage"/>
+
+        <!--See success messages-->
+        <see selector="{{CheckoutSuccessMainSection.successTitle}}" userInput="Thank you for your purchase!" stepKey="seeSuccessTitle"/>
+        <see selector="{{CheckoutSuccessMainSection.orderNumberText}}" userInput="Your order # is: " stepKey="seeOrderNumber"/>
+
+        <!--Check register section-->
+        <see selector="{{CheckoutSuccessMainSection.success}}" userInput="We'll email you an order confirmation with details and tracking info." stepKey="seeSuccessNotify"/>
+        <see selector="{{CheckoutSuccessRegisterSection.registerMessage}}" userInput="You can track your order status by creating an account." stepKey="seeRegisterMessage"/>
+        <see selector="{{CheckoutSuccessRegisterSection.customerEmail}}" userInput="Email Address: {{CustomerEntityOne.email}}" stepKey="seeCustomerEmail"/>
+        <seeElement selector="{{CheckoutSuccessRegisterSection.createAccountButton}}" stepKey="seeVisibleCreateAccountButton"/>
+        <click selector="{{CheckoutSuccessRegisterSection.createAccountButton}}" stepKey="clickCreateAccountButton"/>
+        <waitForPageLoad stepKey="waitAccountPage"/>
+        <seeInCurrentUrl url="{{StorefrontCustomerCreatePage.url}}" stepKey="seeHomePageUrl"/>
+        <see userInput="Create New Customer Account" selector="{{StorefrontHeaderSection.mainTitle}}" stepKey="seeHomePageTitle"/>
+
+        <!--Go to product page-->
+        <amOnPage url="$$createSimpleProduct.custom_attributes[url_key]$$.html" stepKey="navigateToSimpleProductPage2"/>
+        <waitForPageLoad stepKey="waitForCatalogPageLoad2"/>
+
+        <!--Add Product to Shopping Cart-->
+        <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage2">
+            <argument name="productName" value="$$createSimpleProduct.name$$"/>
+        </actionGroup>
+
+        <!--Go to Checkout-->
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="goToCheckoutFromMinicart2"/>
+
+        <actionGroup ref="GuestCheckoutFillingShippingSectionActionGroup" stepKey="guestCheckoutFillingShippingSection2">
+            <argument name="customerVar" value="CustomerEntityOne" />
+            <argument name="customerAddressVar" value="CustomerAddressSimple" />
+        </actionGroup>
+
+        <!--Click Place Order button-->
+        <click selector="{{CheckoutPaymentSection.placeOrder}}" stepKey="clickPlaceOrder2"/>
+        <see selector="{{CheckoutSuccessMainSection.successTitle}}" userInput="Thank you for your purchase!" stepKey="seeSuccessTitle2"/>
+        <click selector="{{CheckoutSuccessMainSection.continueShoppingButton}}" stepKey="clickContinueShoppingButton2"/>
+        <waitForPageLoad stepKey="waitHomePage2"/>
+        <seeCurrentUrlEquals url="{{_ENV.MAGENTO_BASE_URL}}" stepKey="seeHomePageUrl2"/>
+        <see userInput="Home Page" selector="{{StorefrontHeaderSection.mainTitle}}" stepKey="seeHomePageTitle2"/>
+    </test>
+</tests>

--- a/app/code/Magento/Checkout/i18n/en_US.csv
+++ b/app/code/Magento/Checkout/i18n/en_US.csv
@@ -178,3 +178,6 @@ Payment,Payment
 "Thank you for your purchase!","Thank you for your purchase!"
 "Password", "Password"
 "Something went wrong while saving the page. Please refresh the page and try again.","Something went wrong while saving the page. Please refresh the page and try again."
+"Item in Cart","Item in Cart"
+"Items in Cart","Items in Cart"
+"Close","Close"

--- a/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
@@ -22,7 +22,8 @@
                        type="email"
                        data-bind="
                             textInput: email,
-                            hasFocus: emailFocused"
+                            hasFocus: emailFocused,
+                            mageInit: {'mage/trim-input':{}}"
                        name="username"
                        data-validate="{required:true, 'validate-email':true}"
                        id="customer-email" />

--- a/app/code/Magento/Config/Test/Mftf/Page/AdminSalesConfigPage.xml
+++ b/app/code/Magento/Config/Test/Mftf/Page/AdminSalesConfigPage.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
+    <page name="AdminSalesConfigPage" url="admin/system_config/edit/section/sales/{{var1}}" area="admin" parameterized="true" module="Magento_Config">
+        <section name="AdminSalesConfigSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Config/Test/Mftf/Section/AdminConfigSection.xml
+++ b/app/code/Magento/Config/Test/Mftf/Section/AdminConfigSection.xml
@@ -5,12 +5,10 @@
   * See COPYING.txt for license details.
   */
 -->
+
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
-    <section name="StorefrontHeaderSection">
-        <element name="storeViewSwitcher" type="button" selector="#switcher-language-trigger"/>
-        <element name="storeViewDropdown" type="button" selector="ul.switcher-dropdown"/>
-        <element name="storeViewOption" type="button" selector="li.view-{{var1}}>a" parameterized="true"/>
-        <element name="mainTitle" type="text" selector="#maincontent .page-title"/>
+    <section name="AdminConfigSection">
+        <element name="saveButton" type="button" selector="#save" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Config/Test/Mftf/Section/AdminSalesConfigSection.xml
+++ b/app/code/Magento/Config/Test/Mftf/Section/AdminSalesConfigSection.xml
@@ -5,12 +5,11 @@
   * See COPYING.txt for license details.
   */
 -->
+
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
-    <section name="StorefrontHeaderSection">
-        <element name="storeViewSwitcher" type="button" selector="#switcher-language-trigger"/>
-        <element name="storeViewDropdown" type="button" selector="ul.switcher-dropdown"/>
-        <element name="storeViewOption" type="button" selector="li.view-{{var1}}>a" parameterized="true"/>
-        <element name="mainTitle" type="text" selector="#maincontent .page-title"/>
+    <section name="AdminSalesConfigSection">
+        <element name="enableMAPUseSystemValue" type="checkbox" selector="#sales_msrp_enabled_inherit"/>
+        <element name="enableMAPSelect" type="select" selector="#sales_msrp_enabled"/>
     </section>
 </sections>

--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Attribute/NewAttribute/Product/Created.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Attribute/NewAttribute/Product/Created.php
@@ -16,7 +16,7 @@ class Created extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/new/created.phtml';
+    protected $_template = 'Magento_ConfigurableProduct::catalog/product/attribute/new/created.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config.php
@@ -18,7 +18,7 @@ class Config extends Widget implements TabInterface
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/super/config.phtml';
+    protected $_template = 'Magento_ConfigurableProduct::catalog/product/edit/super/config.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Cookie/etc/adminhtml/system.xml
+++ b/app/code/Magento/Cookie/etc/adminhtml/system.xml
@@ -22,7 +22,7 @@
                     <label>Cookie Domain</label>
                     <backend_model>Magento\Cookie\Model\Config\Backend\Domain</backend_model>
                 </field>
-                <field id="cookie_httponly" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="cookie_httponly" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use HTTP Only</label>
                     <comment>
                         <![CDATA[<strong style="color:red">Warning</strong>:  Do not set to "No". User security could be compromised.]]>

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency.php
@@ -20,7 +20,7 @@ class Currency extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'system/currency/rates.phtml';
+    protected $_template = 'Magento_CurrencySymbol::system/currency/rates.phtml';
 
     /**
      * Prepare layout

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
@@ -16,7 +16,7 @@ class Matrix extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'system/currency/rate/matrix.phtml';
+    protected $_template = 'Magento_CurrencySymbol::system/currency/rate/matrix.phtml';
 
     /**
      * @var \Magento\Directory\Model\CurrencyFactory

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Services.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Services.php
@@ -16,7 +16,7 @@ class Services extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'system/currency/rate/services.phtml';
+    protected $_template = 'Magento_CurrencySymbol::system/currency/rate/services.phtml';
 
     /**
      * @var \Magento\Directory\Model\Currency\Import\Source\ServiceFactory

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Newsletter.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Newsletter.php
@@ -17,7 +17,7 @@ class Newsletter extends \Magento\Backend\Block\Widget\Form\Generic implements T
     /**
      * @var string
      */
-    protected $_template = 'tab/newsletter.phtml';
+    protected $_template = 'Magento_Customer::tab/newsletter.phtml';
 
     /**
      * @var \Magento\Newsletter\Model\SubscriberFactory

--- a/app/code/Magento/Customer/Block/Adminhtml/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Sales/Order/Address/Form/Renderer/Vat.php
@@ -24,7 +24,7 @@ class Vat extends \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element
     /**
      * @var string
      */
-    protected $_template = 'sales/order/create/address/form/renderer/vat.phtml';
+    protected $_template = 'Magento_Customer::sales/order/create/address/form/renderer/vat.phtml';
 
     /**
      * @var \Magento\Framework\Json\EncoderInterface

--- a/app/code/Magento/Customer/Block/Newsletter.php
+++ b/app/code/Magento/Customer/Block/Newsletter.php
@@ -20,7 +20,7 @@ class Newsletter extends \Magento\Customer\Block\Account\Dashboard
     /**
      * @var string
      */
-    protected $_template = 'form/newsletter.phtml';
+    protected $_template = 'Magento_Customer::form/newsletter.phtml';
 
     /**
      * @return bool

--- a/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
@@ -156,6 +156,11 @@ class GroupRepository implements \Magento\Customer\Api\GroupRepositoryInterface
             ->setCode($groupModel->getCode())
             ->setTaxClassId($groupModel->getTaxClassId())
             ->setTaxClassName($groupModel->getTaxClassName());
+
+        if ($group->getExtensionAttributes()) {
+            $groupDataObject->setExtensionAttributes($group->getExtensionAttributes());
+        }
+
         return $groupDataObject;
     }
 

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
@@ -39,6 +39,11 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
     protected $group;
 
     /**
+     * @var \Magento\Customer\Api\Data\GroupInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $factoryCreatedGroup;
+
+    /**
      * @var \Magento\Customer\Model\ResourceModel\Group|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $groupResourceModel;
@@ -153,6 +158,12 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             'group',
             false
         );
+        $this->factoryCreatedGroup = $this->getMockForAbstractClass(
+            \Magento\Customer\Api\Data\GroupInterface::class,
+            [],
+            'group',
+            false
+        );
 
         $this->groupResourceModel = $this->createMock(\Magento\Customer\Model\ResourceModel\Group::class);
     }
@@ -162,16 +173,22 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $groupId = 0;
 
         $taxClass = $this->getMockForAbstractClass(\Magento\Tax\Api\Data\TaxClassInterface::class, [], '', false);
+        $extensionAttributes = $this->getMockForAbstractClass(
+            \Magento\Customer\Api\Data\GroupExtensionInterface::class
+        );
 
-        $this->group->expects($this->once())
+        $this->group->expects($this->atLeastOnce())
             ->method('getCode')
             ->willReturn('Code');
         $this->group->expects($this->atLeastOnce())
             ->method('getId')
             ->willReturn($groupId);
-        $this->group->expects($this->once())
+        $this->group->expects($this->atLeastOnce())
             ->method('getTaxClassId')
             ->willReturn(17);
+        $this->group->expects($this->atLeastOnce())
+            ->method('getExtensionAttributes')
+            ->willReturn($extensionAttributes);
 
         $this->groupModel->expects($this->atLeastOnce())
             ->method('getId')
@@ -185,22 +202,33 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->groupModel->expects($this->atLeastOnce())
             ->method('getTaxClassName')
             ->willReturn('Tax class name');
-        $this->group->expects($this->once())
+
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setId')
             ->with($groupId)
             ->willReturnSelf();
-        $this->group->expects($this->once())
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setCode')
             ->with('Code')
             ->willReturnSelf();
-        $this->group->expects($this->once())
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setTaxClassId')
             ->with(234)
             ->willReturnSelf();
-        $this->group->expects($this->once())
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setTaxClassName')
             ->with('Tax class name')
             ->willReturnSelf();
+        $this->factoryCreatedGroup->expects($this->once())
+            ->method('setExtensionAttributes')
+            ->with($extensionAttributes)
+            ->willReturnSelf();
+        $this->factoryCreatedGroup->expects($this->atLeastOnce())
+            ->method('getCode')
+            ->willReturn('Code');
+        $this->factoryCreatedGroup->expects($this->atLeastOnce())
+            ->method('getTaxClassId')
+            ->willReturn(17);
 
         $this->taxClassRepository->expects($this->once())
             ->method('get')
@@ -229,9 +257,12 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             ->with($groupId);
         $this->groupDataFactory->expects($this->once())
             ->method('create')
-            ->willReturn($this->group);
+            ->willReturn($this->factoryCreatedGroup);
 
-        $this->assertSame($this->group, $this->model->save($this->group));
+        $updatedGroup = $this->model->save($this->group);
+
+        $this->assertSame($this->group->getCode(), $updatedGroup->getCode());
+        $this->assertSame($this->group->getTaxClassId(), $updatedGroup->getTaxClassId());
     }
 
     /**

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -26,7 +26,7 @@
             </group>
             <group id="create_account" translate="label" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Create New Account Options</label>
-                <field id="auto_group_assign" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="auto_group_assign" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Automatic Assignment to Customer Group</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
@@ -170,7 +170,7 @@
                     <comment>Use 0 to disable account locking.</comment>
                     <frontend_class>required-entry validate-digits</frontend_class>
                 </field>
-                <field id="lockout_threshold" translate="label" sortOrder="80" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="lockout_threshold" translate="label comment" sortOrder="80" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Lockout Time (minutes)</label>
                     <comment>Account will be unlocked after provided time.</comment>
                     <frontend_class>required-entry validate-digits</frontend_class>
@@ -272,16 +272,16 @@
             </group>
             <group id="address_templates" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Address Templates</label>
-                <field id="text" type="textarea" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="text" translate="label" type="textarea" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Text</label>
                 </field>
-                <field id="oneline" type="textarea" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="oneline" translate="label" type="textarea" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Text One Line</label>
                 </field>
-                <field id="html" type="textarea" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="html" translate="label" type="textarea" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>HTML</label>
                 </field>
-                <field id="pdf" type="textarea" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="pdf" translate="label" type="textarea" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>PDF</label>
                 </field>
             </group>

--- a/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
@@ -20,7 +20,7 @@
         <div class="field email required">
             <label for="email_address" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" alt="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmailValue()) ?>" data-validate="{required:true, 'validate-email':true}">
+                <input type="email" name="email" alt="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmailValue()) ?>" data-mage-init='{"mage/trim-input":{}}' data-validate="{required:true, 'validate-email':true}">
             </div>
         </div>
         <?= $block->getChildHtml('form_additional_info') ?>

--- a/app/code/Magento/Developer/Model/Di/PluginList.php
+++ b/app/code/Magento/Developer/Model/Di/PluginList.php
@@ -145,7 +145,10 @@ class PluginList extends Interception\PluginList\PluginList
             if (!array_key_exists($pluginInstance, $this->pluginList[$this->pluginTypeMapping[$typeCode]])) {
                 $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance] = [];
             }
-            $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance][] = $pluginMethod ;
+
+            if (!in_array($pluginMethod, $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance])) {
+                $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance][] = $pluginMethod;
+            }
         }
     }
 }

--- a/app/code/Magento/Developer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Developer/etc/adminhtml/system.xml
@@ -6,7 +6,7 @@
  */-->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="dev" translate="label">
+        <section id="dev">
             <group id="front_end_development_workflow" translate="label" type="text" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Frontend Development Workflow</label>
                 <field id="type" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
@@ -25,7 +25,7 @@
                     <backend_model>Magento\Developer\Model\Config\Backend\AllowedIps</backend_model>
                 </field>
             </group>
-            <group id="debug" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="debug" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <field id="debug_logging" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Log to File</label>
                     <comment>Not available in production mode.</comment>

--- a/app/code/Magento/Dhl/etc/adminhtml/system.xml
+++ b/app/code/Magento/Dhl/etc/adminhtml/system.xml
@@ -94,7 +94,7 @@
                         <field id="content_type">N</field>
                     </depends>
                 </field>
-                <field id="ready_time" type="text" sortOrder="180" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="ready_time" translate="label comment" type="text" sortOrder="180" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Ready time</label>
                     <comment>Package ready time after order submission (in hours)</comment>
                 </field>

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -33,7 +33,7 @@ class Downloadable extends Widget implements TabInterface
     /**
      * @var string
      */
-    protected $_template = 'product/edit/downloadable.phtml';
+    protected $_template = 'Magento_Downloadable::product/edit/downloadable.phtml';
 
     /**
      * Accordion block id

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -30,7 +30,7 @@ class Links extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'product/edit/downloadable/links.phtml';
+    protected $_template = 'Magento_Downloadable::product/edit/downloadable/links.phtml';
 
     /**
      * Downloadable file

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -22,7 +22,7 @@ class Samples extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'product/edit/downloadable/samples.phtml';
+    protected $_template = 'Magento_Downloadable::product/edit/downloadable/samples.phtml';
 
     /**
      * Downloadable file

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -17,5 +17,5 @@ class Js extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'attribute/edit/js.phtml';
+    protected $_template = 'Magento_Eav::attribute/edit/js.phtml';
 }

--- a/app/code/Magento/Email/Block/Adminhtml/Template.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template.php
@@ -22,7 +22,7 @@ class Template extends \Magento\Backend\Block\Template implements \Magento\Backe
      *
      * @var string
      */
-    protected $_template = 'template/list.phtml';
+    protected $_template = 'Magento_Email::template/list.phtml';
 
     /**
      * @var \Magento\Backend\Block\Widget\Button\ButtonList

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Edit.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Edit.php
@@ -42,7 +42,7 @@ class Edit extends Widget implements ContainerInterface
      *
      * @var string
      */
-    protected $_template = 'template/edit.phtml';
+    protected $_template = 'Magento_Email::template/edit.phtml';
 
     /**
      * @var \Magento\Framework\Json\EncoderInterface

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -33,7 +33,7 @@ class Inline extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'inline.phtml';
+    protected $_template = 'Magento_GiftMessage::inline.phtml';
 
     /**
      * Gift message message

--- a/app/code/Magento/GoogleOptimizer/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleOptimizer/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="google" translate="label">
+        <section id="google">
             <group id="analytics">
                 <field id="experiments" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Content Experiments</label>

--- a/app/code/Magento/GroupedProduct/etc/adminhtml/system.xml
+++ b/app/code/Magento/GroupedProduct/etc/adminhtml/system.xml
@@ -7,8 +7,8 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="checkout" translate="label" type="text" sortOrder="305" showInDefault="1" showInWebsite="1" showInStore="1">
-            <group id="cart" translate="label" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="checkout" type="text" sortOrder="305" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="cart" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                 <field id="grouped_product_image" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Grouped Product Image</label>
                     <source_model>Magento\Catalog\Model\Config\Source\Product\Thumbnail</source_model>

--- a/app/code/Magento/InstantPurchase/etc/adminhtml/system.xml
+++ b/app/code/Magento/InstantPurchase/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
         <section id="sales">
             <group id="instant_purchase" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Instant Purchase</label>
-                <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="active" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Payment method with vault and instant purchase support should be enabled.</comment>

--- a/app/code/Magento/Integration/etc/adminhtml/system.xml
+++ b/app/code/Magento/Integration/etc/adminhtml/system.xml
@@ -13,48 +13,48 @@
             <resource>Magento_Integration::config_oauth</resource>
             <group id="access_token_lifetime" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Access Token Expiration</label>
-                <field id="customer" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="customer" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Customer Token Lifetime (hours)</label>
                     <comment>We will disable this feature if the value is empty.</comment>
                 </field>
-                <field id="admin" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="admin" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Admin Token Lifetime (hours)</label>
                     <comment>We will disable this feature if the value is empty.</comment>
                 </field>
             </group>
             <group id="cleanup" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Cleanup Settings</label>
-                <field id="cleanup_probability" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="cleanup_probability" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Cleanup Probability</label>
                     <comment>Integer. Launch cleanup in X OAuth requests. 0 (not recommended) - to disable cleanup</comment>
                 </field>
-                <field id="expiration_period" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="expiration_period" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Expiration Period</label>
                     <comment>Cleanup entries older than X minutes.</comment>
                 </field>
             </group>
             <group id="consumer" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Consumer Settings</label>
-                <field id="expiration_period" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="expiration_period" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Expiration Period</label>
                     <comment>Consumer key/secret will expire if not used within X seconds after Oauth token exchange starts.</comment>
                 </field>
-                <field id="post_maxredirects" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="post_maxredirects" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>OAuth consumer credentials HTTP Post maxredirects</label>
                     <comment>Number of maximum redirects for OAuth consumer credentials Post request.</comment>
                 </field>
-                <field id="post_timeout" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="post_timeout" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>OAuth consumer credentials HTTP Post timeout</label>
                     <comment>Timeout for OAuth consumer credentials Post request within X seconds.</comment>
                 </field>
             </group>
             <group id="authentication_lock" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Authentication Locks</label>
-                <field id="max_failures_count" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="max_failures_count" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Maximum Login Failures to Lock Out Account</label>
                     <comment>Maximum Number of authentication failures to lock out account.</comment>
                 </field>
-                <field id="timeout" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="timeout" translate="label" type="text comment" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Lockout Time (seconds)</label>
                     <comment>Period of time in seconds after which account will be unlocked.</comment>
                 </field>

--- a/app/code/Magento/LayeredNavigation/Block/Navigation/State.php
+++ b/app/code/Magento/LayeredNavigation/Block/Navigation/State.php
@@ -18,7 +18,7 @@ class State extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'layer/state.phtml';
+    protected $_template = 'Magento_LayeredNavigation::layer/state.phtml';
 
     /**
      * Catalog layer

--- a/app/code/Magento/LayeredNavigation/etc/adminhtml/system.xml
+++ b/app/code/Magento/LayeredNavigation/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="catalog" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="catalog" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="layered_navigation" translate="label" sortOrder="490" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Layered Navigation</label>
                 <field id="display_product_count" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">

--- a/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
+++ b/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="system" translate="label" type="text" sortOrder="900" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="system" type="text" sortOrder="900" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="media_storage_configuration" translate="label" type="text" sortOrder="900" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Storage Configuration for Media</label>
                 <field id="media_storage" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">

--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -23,6 +23,7 @@
                 <div class="control">
                     <input name="email" type="email" id="newsletter"
                                 placeholder="<?= $block->escapeHtmlAttr(__('Enter your email address')) ?>"
+                                data-mage-init='{"mage/trim-input":{}}'
                                 data-validate="{required:true, 'validate-email':true}"/>
                 </div>
             </div>

--- a/app/code/Magento/OfflinePayments/etc/adminhtml/system.xml
+++ b/app/code/Magento/OfflinePayments/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="payment" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="payment" type="text" sortOrder="400" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="checkmo" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Check / Money Order</label>
                 <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">

--- a/app/code/Magento/OfflineShipping/etc/adminhtml/system.xml
+++ b/app/code/Magento/OfflineShipping/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="carriers" translate="label" type="text" sortOrder="320" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="carriers" type="text" sortOrder="320" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="flatrate" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Flat Rate</label>
                 <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">

--- a/app/code/Magento/PageCache/etc/adminhtml/system.xml
+++ b/app/code/Magento/PageCache/etc/adminhtml/system.xml
@@ -49,7 +49,7 @@
                             <field id="caching_application">1</field>
                         </depends>
                     </field>
-                    <field id="export_button_version4" type="button" sortOrder="35" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <field id="export_button_version4" translate="label" type="button" sortOrder="35" showInDefault="1" showInWebsite="0" showInStore="0">
                         <label>Export Configuration</label>
                         <frontend_model>Magento\PageCache\Block\System\Config\Form\Field\Export\Varnish4</frontend_model>
                         <depends>

--- a/app/code/Magento/Paypal/etc/adminhtml/system.xml
+++ b/app/code/Magento/Paypal/etc/adminhtml/system.xml
@@ -77,7 +77,7 @@
                     <group id="configuration_details">
                         <comment>http://docs.magento.com/m2/ce/user_guide/payment/paypal-payments-pro.html</comment>
                     </group>
-                    <group id="paypal_payflow_required" translate="label" showInDefault="1" showInWebsite="1" sortOrder="10">
+                    <group id="paypal_payflow_required" showInDefault="1" showInWebsite="1" sortOrder="10">
                         <field id="enable_paypal_payflow">
                             <attribute type="shared">0</attribute>
                             <config_path>payment/paypal_payment_pro/active</config_path>
@@ -90,7 +90,7 @@
                         <label>Basic Settings - PayPal Payments Pro</label>
                     </group>
                 </group>
-                <group id="wps_express" extends="payment_all_paypal/express_checkout">
+                <group id="wps_express" translate="label comment" extends="payment_all_paypal/express_checkout">
                     <label>Payments Standard</label>
                     <comment>Accept credit card and PayPal payments securely.</comment>
                     <attribute type="activity_path">payment/wps_express/active</attribute>
@@ -110,7 +110,7 @@
                             <config_path>payment/wps_express_bml/active</config_path>
                         </field>
                     </group>
-                    <group id="settings_ec">
+                    <group id="settings_ec" translate="label">
                         <label>Basic Settings - PayPal Website Payments Standard</label>
                     </group>
                 </group>
@@ -124,7 +124,7 @@
                 <group id="payflow_link_us" extends="payment_all_paypal/payflow_link"/>
             </group>
         </section>
-        <section id="payment_gb" extends="payment"  showInDefault="0" showInWebsite="0" showInStore="0">
+        <section id="payment_gb" extends="payment" showInDefault="0" showInWebsite="0" showInStore="0">
             <group id="paypal_alternative_payment_methods" sortOrder="5" showInDefault="0" showInWebsite="0" showInStore="0">
                 <group id="express_checkout_gb" translate="label comment" extends="payment_all_paypal/express_checkout" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>PayPal Express Checkout</label>
@@ -158,7 +158,7 @@
                     </group>
                 </group>
                 <include path="Magento_Paypal::system/payments_pro_hosted_solution_with_express_checkout.xml"/>
-                <group id="wps_express" extends="payment_all_paypal/express_checkout" sortOrder="50">
+                <group id="wps_express" translate="label comment" extends="payment_all_paypal/express_checkout" sortOrder="50">
                     <label>Website Payments Standard</label>
                     <comment>Accept credit card and PayPal payments securely.</comment>
                     <attribute type="activity_path">payment/wps_express/active</attribute>
@@ -166,7 +166,7 @@
                         <comment>http://docs.magento.com/m2/ce/user_guide/payment/paypal-payments-standard.html</comment>
                     </group>
                     <group id="express_checkout_required">
-                        <group id="express_checkout_required_express_checkout">
+                        <group id="express_checkout_required_express_checkout" translate="label">
                             <label>Website Payments Standard</label>
                         </group>
                         <field id="enable_in_context_checkout" showInDefault="0" showInWebsite="0"/>
@@ -178,7 +178,7 @@
                         <field id="express_checkout_bml_sort_order" showInDefault="0" showInWebsite="0"/>
                         <group id="advertise_bml" showInDefault="0" showInWebsite="0"/>
                     </group>
-                    <group id="settings_ec">
+                    <group id="settings_ec" translate="label">
                         <label>Basic Settings - PayPal Website Payments Standard</label>
                     </group>
                 </group>
@@ -227,7 +227,7 @@
                 <comment>Choose a secure bundled payment solution for your business.</comment>
                 <help_url>https://www.paypal-marketing.com/emarketing/partner/na/merchantlineup/home.page#mainTab=checkoutlineup&amp;subTab=newlineup</help_url>
                 <attribute type="displayIn">other_paypal_payment_solutions</attribute>
-                <group id="wps_other" extends="payment_all_paypal/express_checkout" showInDefault="1" showInWebsite="1" showInStore="1">
+                <group id="wps_other" translate="label comment" extends="payment_all_paypal/express_checkout" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Website Payments Standard</label>
                     <fieldset_css>complex</fieldset_css>
                     <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
@@ -237,7 +237,7 @@
                         <comment>http://docs.magento.com/m2/ce/user_guide/payment/paypal-payments-standard.html</comment>
                     </group>
                     <group id="express_checkout_required">
-                        <group id="express_checkout_required_express_checkout">
+                        <group id="express_checkout_required_express_checkout" translate="label">
                             <label>Website Payments Standard</label>
                         </group>
                         <field id="enable_in_context_checkout" showInDefault="0" showInWebsite="0"/>
@@ -271,7 +271,7 @@
             <group id="paypal_group_all_in_one">
                 <group id="wps_other" sortOrder="20"/>
             </group>
-            <group id="paypal_payment_gateways" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="paypal_payment_gateways" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
                 <fieldset_css>complex paypal-other-section paypal-gateways-section</fieldset_css>
                 <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Expanded</frontend_model>
                 <label><![CDATA[PayPal Payment Gateways&nbsp;<i>Process payments using your own internet merchant account.</i>]]></label>

--- a/app/code/Magento/Sales/Test/Mftf/Page/AdminOrderDetailsPage.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Page/AdminOrderDetailsPage.xml
@@ -10,5 +10,10 @@
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
     <page name="AdminOrderDetailsPage" url="sales/order/view/order_id/" area="admin" module="Magento_Sales">
         <section name="AdminOrderFormTotalSection"/>
+        <section name="OrderDetailsMainActionsSection"/>
+        <section name="OrderDetailsInformationSection"/>
+        <section name="OrderDetailsMessagesSection"/>
+        <section name="AdminOrderItemsOrderedSection"/>
+        <section name="AdminOrderTotalSection" />
     </page>
 </pages>

--- a/app/code/Magento/Sales/Test/Mftf/Page/OrderDetailsPage.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Page/OrderDetailsPage.xml
@@ -8,11 +8,6 @@
 
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
-    <page name="OrderDetailsPage" url="/sales/order/view/order_id/" area="admin" module="Magento_Sales">
-        <section name="OrderDetailsMainActionsSection"/>
-        <section name="OrderDetailsInformationSection"/>
-        <section name="OrderDetailsMessagesSection"/>
-        <section name="AdminOrderItemsOrderedSection"/>
-        <section name="AdminOrderTotalSection" />
+    <page name="OrderDetailsPage" url="/sales/order/view/order_id/" area="storefront" module="Magento_Sales">
     </page>
 </pages>

--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -393,7 +393,7 @@
             </group>
         </section>
         <section id="rss">
-            <group id="order" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="order" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Order</label>
                 <field id="status" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Customer Order Status Notification</label>
@@ -402,7 +402,7 @@
             </group>
         </section>
         <section id="dev">
-            <group id="grid" type="text" sortOrder="131" showInDefault="1" showInWebsite="0" showInStore="0">
+            <group id="grid" translate="label" type="text" sortOrder="131" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Grid Settings</label>
                 <field id="async_indexing" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Asynchronous indexing</label>

--- a/app/code/Magento/SendFriend/view/frontend/templates/send.phtml
+++ b/app/code/Magento/SendFriend/view/frontend/templates/send.phtml
@@ -35,6 +35,7 @@
             <div class="control">
                 <input name="recipients[email][<%- data._index_ %>]" title="<?= $block->escapeHtmlAttr(__('Email')) ?>"
                        id="recipients-email<%- data._index_ %>" type="email" class="input-text"
+                       data-mage-init='{"mage/trim-input":{}}'
                        data-validate="{required:true, 'validate-email':true}"/>
             </div>
         </div>
@@ -72,7 +73,8 @@
             <label for="sender-email" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
                 <input name="sender[email]" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>" id="sender-email" type="text" class="input-text"
+                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>" id="sender-email" type="email" class="input-text"
+                       data-mage-init='{"mage/trim-input":{}}'
                        data-validate="{required:true, 'validate-email':true}"/>
             </div>
         </div>

--- a/app/code/Magento/Signifyd/etc/adminhtml/system.xml
+++ b/app/code/Magento/Signifyd/etc/adminhtml/system.xml
@@ -11,7 +11,7 @@
             <label>Fraud Protection</label>
             <tab>sales</tab>
             <resource>Magento_Sales::fraud_protection</resource>
-            <group id="signifyd" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+            <group id="signifyd" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
                 <fieldset_css>signifyd-logo-header</fieldset_css>
                 <group id="about" translate="label comment" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
                     <frontend_model>Magento\Signifyd\Block\Adminhtml\System\Config\Fieldset\Info</frontend_model>
@@ -52,7 +52,7 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>fraud_protection/signifyd/debug</config_path>
                     </field>
-                    <field id="webhook_url" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="webhook_url" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Webhook URL</label>
                         <comment><![CDATA[Your webhook URL will be used to <a href="https://app.signifyd.com/settings/notifications" target="_blank">configure</a> a guarantee completed webhook in Signifyd. Webhooks are used to sync Signifyd`s guarantee decisions back to Magento.]]></comment>
                         <attribute type="handler_url">signifyd/webhooks/handler</attribute>

--- a/app/code/Magento/Swatches/etc/adminhtml/system.xml
+++ b/app/code/Magento/Swatches/etc/adminhtml/system.xml
@@ -7,8 +7,8 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="catalog" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-            <group id="frontend" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="catalog" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="frontend" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                 <field id="swatches_per_product" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Swatches per Product</label>
                 </field>

--- a/app/code/Magento/Tax/etc/adminhtml/system.xml
+++ b/app/code/Magento/Tax/etc/adminhtml/system.xml
@@ -62,7 +62,7 @@
                     <backend_model>Magento\Tax\Model\Config\Notification</backend_model>
                     <comment>Warning: To apply the discount on prices including tax and apply the tax after discount, set Catalog Prices to “Including Tax”.</comment>
                 </field>
-                <field id="apply_tax_on" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="apply_tax_on" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Apply Tax On</label>
                     <source_model>Magento\Tax\Model\Config\Source\Apply\On</source_model>
                 </field>

--- a/app/code/Magento/Theme/view/frontend/web/js/row-builder.js
+++ b/app/code/Magento/Theme/view/frontend/web/js/row-builder.js
@@ -144,7 +144,7 @@ define([
 
             $(tmpl).appendTo(row);
 
-            $(this.options.rowContainer).append(row);
+            $(this.options.rowContainer).append(row).trigger('contentUpdated');
 
             row.addClass(this.options.additionalRowClass);
 

--- a/app/code/Magento/Translation/etc/adminhtml/system.xml
+++ b/app/code/Magento/Translation/etc/adminhtml/system.xml
@@ -9,7 +9,7 @@
     <system>
         <section id="dev">
             <group id="js">
-                <field id="translate_strategy" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="translate_strategy" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Translation Strategy</label>
                     <source_model>Magento\Translation\Model\Js\Config\Source\Strategy</source_model>
                     <comment>Please put your store into maintenance mode and redeploy static files after changing strategy</comment>

--- a/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
@@ -9,7 +9,6 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Ui\Component\MassAction\Filter;
 
 /**
@@ -18,7 +17,7 @@ use Magento\Ui\Component\MassAction\Filter;
 class ConvertToCsv
 {
     /**
-     * @var WriteInterface
+     * @var DirectoryList
      */
     protected $directory;
 

--- a/app/code/Magento/Ui/Model/Export/ConvertToXml.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToXml.php
@@ -13,7 +13,6 @@ use Magento\Framework\Convert\ExcelFactory;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Ui\Component\MassAction\Filter;
 
 /**
@@ -22,7 +21,7 @@ use Magento\Ui\Component\MassAction\Filter;
 class ConvertToXml
 {
     /**
-     * @var WriteInterface
+     * @var DirectoryList
      */
     protected $directory;
 

--- a/app/code/Magento/Ui/etc/adminhtml/system.xml
+++ b/app/code/Magento/Ui/etc/adminhtml/system.xml
@@ -9,12 +9,12 @@
     <system>
         <section id="dev">
             <group id="js">
-                <field id="session_storage_logging" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="session_storage_logging" translate="label comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Log JS Errors to Session Storage</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>If enabled, can be used by functional tests for extended reporting</comment>
                 </field>
-                <field id="session_storage_key" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="session_storage_key" translate="label comment" type="text" sortOrder="110" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Log JS Errors to Session Storage Key</label>
                     <comment>Use this key to retrieve collected js errors</comment>
                 </field>

--- a/app/code/Magento/WebapiSecurity/etc/adminhtml/system.xml
+++ b/app/code/Magento/WebapiSecurity/etc/adminhtml/system.xml
@@ -8,7 +8,7 @@
         <section id="webapi" translate="label" type="text" sortOrder="102" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="webapisecurity" translate="label" type="text" sortOrder="250" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Web API Security</label>
-                <field id="allow_insecure" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="allow_insecure" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Allow Anonymous Guest Access</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>This feature applies only to CMS, Catalog and Store APIs. Please consult your developers for details on potential security risks.</comment>

--- a/app/code/Magento/Wishlist/etc/adminhtml/system.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/system.xml
@@ -22,12 +22,12 @@
                     <comment>Email template chosen based on theme fallback when "Default" option is selected.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Email\Template</source_model>
                 </field>
-                <field id="number_limit" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="number_limit" translate="label comment" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Max Emails Allowed to be Sent</label>
                     <comment>10 by default. Max - 10000</comment>
                     <validate>validate-digits validate-digits-range digits-range-1-10000</validate>
                 </field>
-                <field id="text_limit" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="text_limit" translate="label comment" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Email Text Length Limit</label>
                     <comment>255 by default</comment>
                     <validate>validate-digits validate-digits-range digits-range-1-10000</validate>

--- a/dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/CreateOnlineCreditMemoPayflowLinkTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/CreateOnlineCreditMemoPayflowLinkTest.xml
@@ -6,7 +6,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
-    <testCase name="Magento\Paypal\Test\TestCase\CreateOnlineCreditMemoPayflowLinkTest" summary="Create online credit memo for order placed with with PayPal Payflow Link">
+    <testCase name="Magento\Paypal\Test\TestCase\CreateOnlineCreditMemoPayflowLinkTest" summary="Create online credit memo for order placed with PayPal Payflow Link">
         <variation name="CreateOnlineCreditMemoPayflowLinkVariation1" summary="Create Refund for Order Paid with PayPal Payflow Link" ticketId="MAGETWO-13061">
             <data name="tag" xsi:type="string">test_type:3rd_party_test, severity:S0</data>
             <data name="products/0" xsi:type="string">catalogProductSimple::product_100_dollar</data>

--- a/dev/tests/functional/tests/app/Magento/SalesRule/Test/Repository/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Magento/SalesRule/Test/Repository/SalesRule.xml
@@ -96,8 +96,8 @@
             <field name="stop_rules_processing" xsi:type="string">Yes</field>
         </dataset>
         <dataset name="active_sales_rule_with_complex_conditions">
-            <field name="name" xsi:type="string">Cart Price Rule with with complex conditions %isolation%</field>
-            <field name="description" xsi:type="string">Cart Price Rule with with complex conditions</field>
+            <field name="name" xsi:type="string">Cart Price Rule with complex conditions %isolation%</field>
+            <field name="description" xsi:type="string">Cart Price Rule with complex conditions</field>
             <field name="is_active" xsi:type="string">Yes</field>
             <field name="website_ids" xsi:type="array">
                 <item name="0" xsi:type="string">Main Website</item>
@@ -129,8 +129,8 @@
             <field name="stop_rules_processing" xsi:type="string">Yes</field>
             <field name="simple_free_shipping" xsi:type="string">For matching items only</field>
             <field name="store_labels" xsi:type="array">
-                <item name="0" xsi:type="string">Cart Price Rule with with complex conditions</item>
-                <item name="1" xsi:type="string">Cart Price Rule with with complex conditions</item>
+                <item name="0" xsi:type="string">Cart Price Rule with complex conditions</item>
+                <item name="1" xsi:type="string">Cart Price Rule with complex conditions</item>
             </field>
         </dataset>
 

--- a/dev/tests/functional/tests/app/Magento/Search/Test/Fixture/SynonymGroup.xml
+++ b/dev/tests/functional/tests/app/Magento/Search/Test/Fixture/SynonymGroup.xml
@@ -13,7 +13,7 @@
              collection="Magento\Search\Model\ResourceModel\Block\Grid\Collection"
              handler_interface="Magento\Search\Test\Handler\SynonymGroup\SynonymGroupInterface"
              repository_class="Magento\Search\Test\Repository\SynonymGroup" class="Magento\Search\Test\Fixture\SynonymGroup">
-        <field name="group_id" is_required="1 "/>
+        <field name="group_id" is_required="1"/>
         <field name="synonyms" is_required="0" />
         <field name="scope_id" is_required="0" source="Magento\Search\Test\Fixture\SynonymGroup\ScopeId" />
         <field name="mergeOnConflict" is_required="0" />

--- a/dev/tests/functional/tests/app/Magento/Weee/Test/TestCase/CreateTaxWithFptTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Weee/Test/TestCase/CreateTaxWithFptTest.xml
@@ -97,7 +97,7 @@
         </variation>
         <variation name="CreateTaxWithFptTestVariation5" firstConstraint="Magento\Weee\Test\Constraint\AssertFptApplied" method="test">
             <data name="tag" xsi:type="string">to_maintain:yes</data>
-            <data name="description" xsi:type="string">Check taxed FPT display set to Excluding, Description and Including FPT on product with with custom option catalog price Excluding Tax</data>
+            <data name="description" xsi:type="string">Check taxed FPT display set to Excluding, Description and Including FPT on product with custom option catalog price Excluding Tax</data>
             <data name="configData" xsi:type="string">shipping_tax_class_taxable_goods,tax_with_fpt_taxed_cat_excl_disc_on_excl</data>
             <data name="productData" xsi:type="string">with_custom_option_and_fpt</data>
             <data name="prices/category_price" xsi:type="string">70.00</data>
@@ -117,7 +117,7 @@
             <constraint name="Magento\Weee\Test\Constraint\AssertFptApplied" />
         </variation>
         <variation name="CreateTaxWithFptTestVariation6" firstConstraint="Magento\Weee\Test\Constraint\AssertFptApplied" method="test">
-            <data name="description" xsi:type="string">Check taxed FPT display set to Including FPT and Description on product with with custom option catalog price Excluding Tax</data>
+            <data name="description" xsi:type="string">Check taxed FPT display set to Including FPT and Description on product with custom option catalog price Excluding Tax</data>
             <data name="configData" xsi:type="string">shipping_tax_class_taxable_goods,tax_with_fpt_taxed_cat_excl_disc_on_incl, display_including_tax</data>
             <data name="productData" xsi:type="string">with_custom_option_and_fpt</data>
             <data name="prices/category_price" xsi:type="string">86.60</data>
@@ -173,7 +173,7 @@
             <constraint name="Magento\Weee\Test\Constraint\AssertFptApplied" />
         </variation>
         <variation name="CreateTaxWithFptTestVariation9" firstConstraint="Magento\Weee\Test\Constraint\AssertFptApplied" method="test">
-            <data name="description" xsi:type="string">Check taxed FPT display set to Excluding, Description and Including FPT on product with with special price and catalog price Including Tax</data>
+            <data name="description" xsi:type="string">Check taxed FPT display set to Excluding, Description and Including FPT on product with special price and catalog price Including Tax</data>
             <data name="configData" xsi:type="string">shipping_tax_class_taxable_goods,tax_with_fpt_taxed_cat_incl_disc_on_excl</data>
             <data name="productData" xsi:type="string">with_special_price_and_fpt</data>
             <data name="prices/category_price" xsi:type="string">92.38</data>
@@ -193,7 +193,7 @@
             <constraint name="Magento\Weee\Test\Constraint\AssertFptApplied" />
         </variation>
         <variation name="CreateTaxWithFptTestVariation10" firstConstraint="Magento\Weee\Test\Constraint\AssertFptApplied" method="test">
-            <data name="description" xsi:type="string">Check taxed FPT display set to Including FPT and Description on product with with special price and catalog price Including Tax</data>
+            <data name="description" xsi:type="string">Check taxed FPT display set to Including FPT and Description on product with special price and catalog price Including Tax</data>
             <data name="configData" xsi:type="string">shipping_tax_class_taxable_goods,tax_with_fpt_taxed_cat_incl_disc_on_incl</data>
             <data name="productData" xsi:type="string">with_special_price_and_fpt</data>
             <data name="prices/category_price" xsi:type="string">101.62</data>
@@ -210,7 +210,7 @@
         </variation>
         <variation name="CreateTaxWithFptTestVariation11" firstConstraint="Magento\Weee\Test\Constraint\AssertFptApplied" method="test">
             <data name="issue" xsi:type="string">MAGETWO-44968: FPT Final price includes tax on custom option, when display is set to excluding tax</data>
-            <data name="description" xsi:type="string">Check taxed FPT display set to Excluding, Description and Including FPT on product with with custom option and catalog price Including Tax</data>
+            <data name="description" xsi:type="string">Check taxed FPT display set to Excluding, Description and Including FPT on product with custom option and catalog price Including Tax</data>
             <data name="configData" xsi:type="string">shipping_tax_class_taxable_goods,tax_with_fpt_taxed_cat_incl_disc_on_excl</data>
             <data name="productData" xsi:type="string">with_custom_option_and_fpt</data>
             <data name="prices/category_price" xsi:type="string">64.67</data>

--- a/dev/tests/integration/testsuite/Magento/Framework/Code/GeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Code/GeneratorTest.php
@@ -5,12 +5,13 @@
  */
 namespace Magento\Framework\Code;
 
-use Magento\Framework\Code\Generator;
+use Magento\Framework\Api\Code\Generator\ExtensionAttributesInterfaceFactoryGenerator;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
 use Magento\Framework\Interception\Code\Generator as InterceptionGenerator;
 use Magento\Framework\ObjectManager\Code\Generator as DIGenerator;
-use Magento\Framework\Api\Code\Generator\ExtensionAttributesInterfaceFactoryGenerator;
 use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/GeneratorTest/SourceClassWithNamespace.php';
 require_once __DIR__ . '/GeneratorTest/ParentClassWithNamespace.php';
@@ -18,60 +19,77 @@ require_once __DIR__ . '/GeneratorTest/SourceClassWithNamespaceExtension.php';
 
 /**
  * @magentoAppIsolation enabled
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class GeneratorTest extends \PHPUnit\Framework\TestCase
+class GeneratorTest extends TestCase
 {
-    const CLASS_NAME_WITH_NAMESPACE = \Magento\Framework\Code\GeneratorTest\SourceClassWithNamespace::class;
+    const CLASS_NAME_WITH_NAMESPACE = GeneratorTest\SourceClassWithNamespace::class;
 
     /**
-     * @var \Magento\Framework\Code\Generator
+     * @var Generator
      */
     protected $_generator;
 
     /**
-     * @var \Magento\Framework\Code\Generator\Io
+     * @var Generator/Io
      */
     protected $_ioObject;
 
     /**
-     * @var \Magento\Framework\Filesystem\Directory\Write
+     * @var Filesystem\Directory\Write
      */
-    protected $varDirectory;
+    private $generatedDirectory;
 
+    /**
+     * @var Filesystem\Directory\Read
+     */
+    private $logDirectory;
+
+    /**
+     * @var string
+     */
+    private $testRelativePath = './Magento/Framework/Code/GeneratorTest/';
+
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->varDirectory = $objectManager->get(
-            \Magento\Framework\Filesystem::class
-        )->getDirectoryWrite(
-            DirectoryList::VAR_DIR
-        );
-        $generationDirectory = $this->varDirectory->getAbsolutePath('generation');
-        $this->_ioObject = new \Magento\Framework\Code\Generator\Io(
-            new \Magento\Framework\Filesystem\Driver\File(),
-            $generationDirectory
-        );
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Filesystem $filesystem */
+        $filesystem = $objectManager->get(Filesystem::class);
+        $this->generatedDirectory = $filesystem->getDirectoryWrite(DirectoryList::GENERATED_CODE);
+        $this->logDirectory = $filesystem->getDirectoryRead(DirectoryList::LOG);
+        $generatedDirectoryAbsolutePath = $this->generatedDirectory->getAbsolutePath();
+        $this->_ioObject = new Generator\Io(new Filesystem\Driver\File(), $generatedDirectoryAbsolutePath);
         $this->_generator = $objectManager->create(
-            \Magento\Framework\Code\Generator::class,
+            Generator::class,
             [
                 'ioObject' => $this->_ioObject,
                 'generatedEntities' => [
                     ExtensionAttributesInterfaceFactoryGenerator::ENTITY_TYPE =>
                         ExtensionAttributesInterfaceFactoryGenerator::class,
-                    DIGenerator\Factory::ENTITY_TYPE => \Magento\Framework\ObjectManager\Code\Generator\Factory::class,
-                    DIGenerator\Proxy::ENTITY_TYPE => \Magento\Framework\ObjectManager\Code\Generator\Proxy::class,
-                    InterceptionGenerator\Interceptor::ENTITY_TYPE =>
-                        \Magento\Framework\Interception\Code\Generator\Interceptor::class,
+                    DIGenerator\Factory::ENTITY_TYPE => DIGenerator\Factory::class,
+                    DIGenerator\Proxy::ENTITY_TYPE => DIGenerator\Proxy::class,
+                    InterceptionGenerator\Interceptor::ENTITY_TYPE => InterceptionGenerator\Interceptor::class,
                 ]
             ]
         );
         $this->_generator->setObjectManager($objectManager);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function tearDown()
     {
-        $this->varDirectory->delete('generation');
         $this->_generator = null;
+        if ($this->generatedDirectory->isExist($this->testRelativePath)) {
+            if (!$this->generatedDirectory->isWritable($this->testRelativePath)) {
+                $this->generatedDirectory->changePermissionsRecursively($this->testRelativePath, 0775, 0664);
+            }
+            $this->generatedDirectory->delete($this->testRelativePath);
+        }
     }
 
     protected function _clearDocBlock($classBody)
@@ -79,81 +97,59 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
         return preg_replace('/(\/\*[\w\W]*)\nclass/', 'class', $classBody);
     }
 
+    /**
+     * Generates a new file with Factory class and compares with the sample from the
+     * SourceClassWithNamespaceFactory.php.sample file.
+     */
     public function testGenerateClassFactoryWithNamespace()
     {
         $factoryClassName = self::CLASS_NAME_WITH_NAMESPACE . 'Factory';
-        $result = false;
-        $generatorResult = $this->_generator->generateClass($factoryClassName);
-        if (\Magento\Framework\Code\Generator::GENERATION_ERROR !== $generatorResult) {
-            $result = true;
-        }
-        $this->assertTrue($result, 'Failed asserting that \'' . (string)$generatorResult . '\' equals \'success\'.');
-
-        $factory = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create($factoryClassName);
-
-        $object = $factory->create();
-        $this->assertInstanceOf(self::CLASS_NAME_WITH_NAMESPACE, $object);
-
-        // This test is only valid if the factory created the object if Autoloader did not pick it up automatically
-        if (\Magento\Framework\Code\Generator::GENERATION_SUCCESS == $generatorResult) {
-            $content = $this->_clearDocBlock(
-                file_get_contents(
-                    $this->_ioObject->generateResultFileName(self::CLASS_NAME_WITH_NAMESPACE . 'Factory')
-                )
-            );
-            $expectedContent = $this->_clearDocBlock(
-                file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceFactory.php.sample')
-            );
-            $this->assertEquals($expectedContent, $content);
-        }
+        $this->assertEquals(Generator::GENERATION_SUCCESS, $this->_generator->generateClass($factoryClassName));
+        $factory = Bootstrap::getObjectManager()->create($factoryClassName);
+        $this->assertInstanceOf(self::CLASS_NAME_WITH_NAMESPACE, $factory->create());
+        $content = $this->_clearDocBlock(
+            file_get_contents($this->_ioObject->generateResultFileName($factoryClassName))
+        );
+        $expectedContent = $this->_clearDocBlock(
+            file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceFactory.php.sample')
+        );
+        $this->assertEquals($expectedContent, $content);
     }
 
+    /**
+     * Generates a new file with Proxy class and compares with the sample from the
+     * SourceClassWithNamespaceProxy.php.sample file.
+     */
     public function testGenerateClassProxyWithNamespace()
     {
         $proxyClassName = self::CLASS_NAME_WITH_NAMESPACE . '\Proxy';
-        $result = false;
-        $generatorResult = $this->_generator->generateClass($proxyClassName);
-        if (\Magento\Framework\Code\Generator::GENERATION_ERROR !== $generatorResult) {
-            $result = true;
-        }
-        $this->assertTrue($result, 'Failed asserting that \'' . (string)$generatorResult . '\' equals \'success\'.');
-
-        $proxy = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create($proxyClassName);
+        $this->assertEquals(Generator::GENERATION_SUCCESS, $this->_generator->generateClass($proxyClassName));
+        $proxy = Bootstrap::getObjectManager()->create($proxyClassName);
         $this->assertInstanceOf(self::CLASS_NAME_WITH_NAMESPACE, $proxy);
-
-        // This test is only valid if the factory created the object if Autoloader did not pick it up automatically
-        if (\Magento\Framework\Code\Generator::GENERATION_SUCCESS == $generatorResult) {
-            $content = $this->_clearDocBlock(
-                file_get_contents($this->_ioObject->generateResultFileName(self::CLASS_NAME_WITH_NAMESPACE . '\Proxy'))
-            );
-            $expectedContent = $this->_clearDocBlock(
-                file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceProxy.php.sample')
-            );
-            $this->assertEquals($expectedContent, $content);
-        }
+        $content = $this->_clearDocBlock(
+            file_get_contents($this->_ioObject->generateResultFileName($proxyClassName))
+        );
+        $expectedContent = $this->_clearDocBlock(
+            file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceProxy.php.sample')
+        );
+        $this->assertEquals($expectedContent, $content);
     }
 
+    /**
+     * Generates a new file with Interceptor class and compares with the sample from the
+     * SourceClassWithNamespaceInterceptor.php.sample file.
+     */
     public function testGenerateClassInterceptorWithNamespace()
     {
         $interceptorClassName = self::CLASS_NAME_WITH_NAMESPACE . '\Interceptor';
-        $result = false;
-        $generatorResult = $this->_generator->generateClass($interceptorClassName);
-        if (\Magento\Framework\Code\Generator::GENERATION_ERROR !== $generatorResult) {
-            $result = true;
-        }
-        $this->assertTrue($result, 'Failed asserting that \'' . (string)$generatorResult . '\' equals \'success\'.');
-
-        if (\Magento\Framework\Code\Generator::GENERATION_SUCCESS == $generatorResult) {
-            $content = $this->_clearDocBlock(
-                file_get_contents(
-                    $this->_ioObject->generateResultFileName(self::CLASS_NAME_WITH_NAMESPACE . '\Interceptor')
-                )
-            );
-            $expectedContent = $this->_clearDocBlock(
-                file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceInterceptor.php.sample')
-            );
-            $this->assertEquals($expectedContent, $content);
-        }
+        $this->assertEquals(Generator::GENERATION_SUCCESS, $this->_generator->generateClass($interceptorClassName));
+        $content = $this->_clearDocBlock(
+            file_get_contents($this->_ioObject->generateResultFileName($interceptorClassName))
+        );
+        $expectedContent = $this->_clearDocBlock(
+            file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceInterceptor.php.sample')
+        );
+        $this->assertEquals($expectedContent, $content);
     }
 
     /**
@@ -163,26 +159,35 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGenerateClassExtensionAttributesInterfaceFactoryWithNamespace()
     {
         $factoryClassName = self::CLASS_NAME_WITH_NAMESPACE . 'ExtensionInterfaceFactory';
-        $this->varDirectory->create(
-            $this->varDirectory->getAbsolutePath('generation') . '/Magento/Framework/Code/GeneratorTest/'
-        );
-
-        $generatorResult = $this->_generator->generateClass($factoryClassName);
-
+        $this->generatedDirectory->create($this->testRelativePath);
+        $this->assertEquals(Generator::GENERATION_SUCCESS, $this->_generator->generateClass($factoryClassName));
         $factory = Bootstrap::getObjectManager()->create($factoryClassName);
-        $object = $factory->create();
-
-        $this->assertEquals($generatorResult, Generator::GENERATION_SUCCESS);
-        $this->assertInstanceOf(self::CLASS_NAME_WITH_NAMESPACE . 'Extension', $object);
-
+        $this->assertInstanceOf(self::CLASS_NAME_WITH_NAMESPACE . 'Extension', $factory->create());
         $content = $this->_clearDocBlock(
-            file_get_contents(
-                $this->_ioObject->generateResultFileName(self::CLASS_NAME_WITH_NAMESPACE . 'ExtensionInterfaceFactory')
-            )
+            file_get_contents($this->_ioObject->generateResultFileName($factoryClassName))
         );
         $expectedContent = $this->_clearDocBlock(
             file_get_contents(__DIR__ . '/_expected/SourceClassWithNamespaceExtensionInterfaceFactory.php.sample')
         );
         $this->assertEquals($expectedContent, $content);
+    }
+
+    /**
+     * It tries to generate a new class file when the generated directory is read-only
+     */
+    public function testGeneratorClassWithErrorSaveClassFile()
+    {
+        $factoryClassName = self::CLASS_NAME_WITH_NAMESPACE . 'Factory';
+        $msgPart = 'Class ' . $factoryClassName . ' generation error: The requested class did not generate properly, '
+            . 'because the \'generated\' directory permission is read-only.';
+        $regexpMsgPart = preg_quote($msgPart);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp("/.*$regexpMsgPart.*/");
+        $this->generatedDirectory->create($this->testRelativePath);
+        $this->generatedDirectory->changePermissionsRecursively($this->testRelativePath, 0555, 0444);
+        $generatorResult = $this->_generator->generateClass($factoryClassName);
+        $this->assertFalse($generatorResult);
+        $pathToSystemLog = $this->logDirectory->getAbsolutePath('system.log');
+        $this->assertContains($msgPart, file_get_contents($pathToSystemLog));
     }
 }

--- a/lib/internal/Magento/Framework/Code/Generator.php
+++ b/lib/internal/Magento/Framework/Code/Generator.php
@@ -7,6 +7,11 @@ namespace Magento\Framework\Code;
 
 use Magento\Framework\Code\Generator\DefinedClasses;
 use Magento\Framework\Code\Generator\EntityAbstract;
+use Magento\Framework\Code\Generator\Io;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Phrase;
+use Magento\Framework\Filesystem\Driver\File;
+use Psr\Log\LoggerInterface;
 
 class Generator
 {
@@ -17,7 +22,7 @@ class Generator
     const GENERATION_SKIP = 'skip';
 
     /**
-     * @var \Magento\Framework\Code\Generator\Io
+     * @var Io
      */
     protected $_ioObject;
 
@@ -32,26 +37,33 @@ class Generator
     protected $definedClasses;
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
-     * @param Generator\Io   $ioObject
-     * @param array          $generatedEntities
+     * Logger instance
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param Generator\Io $ioObject
+     * @param array $generatedEntities
      * @param DefinedClasses $definedClasses
+     * @param LoggerInterface $logger
      */
     public function __construct(
-        \Magento\Framework\Code\Generator\Io $ioObject = null,
+        Io $ioObject = null,
         array $generatedEntities = [],
-        DefinedClasses $definedClasses = null
+        DefinedClasses $definedClasses = null,
+        LoggerInterface $logger = null
     ) {
-        $this->_ioObject = $ioObject
-            ?: new \Magento\Framework\Code\Generator\Io(
-                new \Magento\Framework\Filesystem\Driver\File()
-            );
+        $this->_ioObject = $ioObject ?: new Io(new File());
         $this->definedClasses = $definedClasses ?: new DefinedClasses();
         $this->_generatedEntities = $generatedEntities;
+        $this->logger = $logger;
     }
 
     /**
@@ -111,8 +123,16 @@ class Generator
         if ($generator !== null) {
             $this->tryToLoadSourceClass($className, $generator);
             if (!($file = $generator->generate())) {
+                /** @var $logger LoggerInterface */
                 $errors = $generator->getErrors();
-                throw new \RuntimeException(implode(' ', $errors) . ' in [' . $className . ']');
+                $errors[] = 'Class ' . $className . ' generation error: The requested class did not generate properly, '
+                    . 'because the \'generated\' directory permission is read-only. '
+                    . 'If --- after running the \'bin/magento setup:di:compile\' CLI command when the \'generated\' '
+                    . 'directory permission is set to write --- the requested class did not generate properly, then '
+                    . 'you must add the generated class object to the signature of the related construct method, only.';
+                $message = implode(PHP_EOL, $errors);
+                $this->getLogger()->critical($message);
+                throw new \RuntimeException($message);
             }
             if (!$this->definedClasses->isClassLoadableFromMemory($className)) {
                 $this->_ioObject->includeFile($file);
@@ -122,12 +142,25 @@ class Generator
     }
 
     /**
+     * Retrieve logger
+     *
+     * @return LoggerInterface
+     */
+    private function getLogger()
+    {
+        if (!$this->logger) {
+            $this->logger = $this->getObjectManager()->get(LoggerInterface::class);
+        }
+        return $this->logger;
+    }
+
+    /**
      * Create entity generator
      *
      * @param string $generatorClass
      * @param string $entityName
      * @param string $className
-     * @return \Magento\Framework\Code\Generator\EntityAbstract
+     * @return EntityAbstract
      */
     protected function createGeneratorInstance($generatorClass, $entityName, $className)
     {
@@ -140,10 +173,10 @@ class Generator
     /**
      * Set object manager instance.
      *
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      * @return $this
      */
-    public function setObjectManager(\Magento\Framework\ObjectManagerInterface $objectManager)
+    public function setObjectManager(ObjectManagerInterface $objectManager)
     {
         $this->objectManager = $objectManager;
         return $this;
@@ -152,11 +185,11 @@ class Generator
     /**
      * Get object manager instance.
      *
-     * @return \Magento\Framework\ObjectManagerInterface
+     * @return ObjectManagerInterface
      */
     public function getObjectManager()
     {
-        if (!($this->objectManager instanceof \Magento\Framework\ObjectManagerInterface)) {
+        if (!($this->objectManager instanceof ObjectManagerInterface)) {
             throw new \LogicException(
                 "Object manager was expected to be set using setObjectManger() "
                 . "before getObjectManager() invocation."
@@ -169,7 +202,7 @@ class Generator
      * Try to load/generate source class to check if it is valid or not.
      *
      * @param string $className
-     * @param \Magento\Framework\Code\Generator\EntityAbstract $generator
+     * @param EntityAbstract $generator
      * @return void
      * @throws \RuntimeException
      */
@@ -178,7 +211,7 @@ class Generator
         $sourceClassName = $generator->getSourceClassName();
         if (!$this->definedClasses->isClassLoadable($sourceClassName)) {
             if ($this->generateClass($sourceClassName) !== self::GENERATION_SUCCESS) {
-                $phrase = new \Magento\Framework\Phrase(
+                $phrase = new Phrase(
                     'Source class "%1" for "%2" generation does not exist.',
                     [$sourceClassName, $className]
                 );

--- a/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
@@ -3,14 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Framework\Code\Test\Unit;
 
 use Magento\Framework\Code\Generator;
 use Magento\Framework\Code\Generator\DefinedClasses;
 use Magento\Framework\Code\Generator\Io;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\ObjectManager\Code\Generator\Factory;
+use Magento\Framework\ObjectManager\Code\Generator\Proxy;
+use Magento\Framework\Interception\Code\Generator\Interceptor;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Code\Generator\EntityAbstract;
+use Magento\GeneratedClass\Factory as GeneratedClassFactory;
 
-class GeneratorTest extends \PHPUnit\Framework\TestCase
+class GeneratorTest extends TestCase
 {
     /**
      * Class name parameter value
@@ -22,45 +30,57 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
      *
      * @var array
      */
-    protected $expectedEntities = [
-        'factory' => \Magento\Framework\ObjectManager\Code\Generator\Factory::ENTITY_TYPE,
-        'proxy' => \Magento\Framework\ObjectManager\Code\Generator\Proxy::ENTITY_TYPE,
-        'interceptor' => \Magento\Framework\Interception\Code\Generator\Interceptor::ENTITY_TYPE,
+    private $expectedEntities = [
+        'factory' => Factory::ENTITY_TYPE,
+        'proxy' => Proxy::ENTITY_TYPE,
+        'interceptor' => Interceptor::ENTITY_TYPE,
     ];
 
     /**
      * System under test
      *
-     * @var \Magento\Framework\Code\Generator
+     * @var Generator
      */
-    protected $model;
+    private $model;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|Io */
-    protected $ioObjectMock;
+    /**
+     * @var Io|Mock
+     */
+    private $ioObjectMock;
 
-    /** @var \Magento\Framework\Code\Generator\DefinedClasses | \PHPUnit_Framework_MockObject_MockObject */
-    protected $definedClassesMock;
+    /**
+     * @var DefinedClasses|Mock
+     */
+    private $definedClassesMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
 
     protected function setUp()
     {
-        $this->definedClassesMock = $this->createMock(\Magento\Framework\Code\Generator\DefinedClasses::class);
-        $this->ioObjectMock = $this->getMockBuilder(\Magento\Framework\Code\Generator\Io::class)
+        $this->definedClassesMock = $this->createMock(DefinedClasses::class);
+        $this->ioObjectMock = $this->getMockBuilder(Io::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->model = $this->buildModel(
+        $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+
+        $this->model = new Generator(
             $this->ioObjectMock,
             [
-                'factory' => \Magento\Framework\ObjectManager\Code\Generator\Factory::class,
-                'proxy' => \Magento\Framework\ObjectManager\Code\Generator\Proxy::class,
-                'interceptor' => \Magento\Framework\Interception\Code\Generator\Interceptor::class
+                'factory' => Factory::class,
+                'proxy' => Proxy::class,
+                'interceptor' => Interceptor::class,
             ],
-            $this->definedClassesMock
+            $this->definedClassesMock,
+            $this->loggerMock
         );
     }
 
     public function testGetGeneratedEntities()
     {
-        $this->model = $this->buildModel(
+        $this->model = new Generator(
             $this->ioObjectMock,
             ['factory', 'proxy', 'interceptor'],
             $this->definedClassesMock
@@ -69,14 +89,16 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @param string $className
+     * @param string $entityType
      * @expectedException \RuntimeException
      * @dataProvider generateValidClassDataProvider
      */
     public function testGenerateClass($className, $entityType)
     {
-        $objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $objectManagerMock = $this->createMock(ObjectManagerInterface::class);
         $fullClassName = $className . $entityType;
-        $entityGeneratorMock = $this->getMockBuilder(\Magento\Framework\Code\Generator\EntityAbstract::class)
+        $entityGeneratorMock = $this->getMockBuilder(EntityAbstract::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManagerMock->expects($this->once())->method('create')->willReturn($entityGeneratorMock);
@@ -87,7 +109,7 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGenerateClassWithWrongName()
     {
         $this->assertEquals(
-            \Magento\Framework\Code\Generator::GENERATION_ERROR,
+            Generator::GENERATION_ERROR,
             $this->model->generateClass(self::SOURCE_CLASS)
         );
     }
@@ -95,15 +117,66 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testGenerateClassWithError()
+    public function testGenerateClassWhenClassIsNotGenerationSuccess()
     {
         $expectedEntities = array_values($this->expectedEntities);
         $resultClassName = self::SOURCE_CLASS . ucfirst(array_shift($expectedEntities));
-        $objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
-        $entityGeneratorMock = $this->getMockBuilder(\Magento\Framework\Code\Generator\EntityAbstract::class)
+        $objectManagerMock = $this->createMock(ObjectManagerInterface::class);
+        $entityGeneratorMock = $this->getMockBuilder(EntityAbstract::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManagerMock->expects($this->once())->method('create')->willReturn($entityGeneratorMock);
+        $this->model->setObjectManager($objectManagerMock);
+        $this->model->generateClass($resultClassName);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function testGenerateClassWithErrors()
+    {
+        $expectedEntities = array_values($this->expectedEntities);
+        $resultClassName = self::SOURCE_CLASS . ucfirst(array_shift($expectedEntities));
+        $errorMessages = [
+            'Error message 0',
+            'Error message 1',
+            'Error message 2',
+        ];
+        $mainErrorMessage = 'Class ' . $resultClassName . ' generation error: The requested class did not generate '
+            . 'properly, because the \'generated\' directory permission is read-only. '
+            . 'If --- after running the \'bin/magento setup:di:compile\' CLI command when the \'generated\' '
+            . 'directory permission is set to write --- the requested class did not generate properly, then '
+            . 'you must add the generated class object to the signature of the related construct method, only.';
+        $FinalErrorMessage = implode(PHP_EOL, $errorMessages) . "\n" . $mainErrorMessage;
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($FinalErrorMessage);
+
+        /** @var ObjectManagerInterface|Mock $objectManagerMock */
+        $objectManagerMock = $this->createMock(ObjectManagerInterface::class);
+        /** @var EntityAbstract|Mock $entityGeneratorMock */
+        $entityGeneratorMock = $this->getMockBuilder(EntityAbstract::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $objectManagerMock->expects($this->once())
+            ->method('create')
+            ->willReturn($entityGeneratorMock);
+        $entityGeneratorMock->expects($this->once())
+            ->method('getSourceClassName')
+            ->willReturn(self::SOURCE_CLASS);
+        $this->definedClassesMock->expects($this->once())
+            ->method('isClassLoadable')
+            ->with(self::SOURCE_CLASS)
+            ->willReturn(true);
+        $entityGeneratorMock->expects($this->once())
+            ->method('generate')
+            ->willReturn(false);
+        $entityGeneratorMock->expects($this->once())
+            ->method('getErrors')
+            ->willReturn($errorMessages);
+        $this->loggerMock->expects($this->once())
+            ->method('critical')
+            ->with($FinalErrorMessage);
         $this->model->setObjectManager($objectManagerMock);
         $this->model->generateClass($resultClassName);
     }
@@ -124,14 +197,11 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
         $this->ioObjectMock->expects($this->exactly($includeFileInvokeCount))->method('includeFile');
 
         $this->assertEquals(
-            \Magento\Framework\Code\Generator::GENERATION_SKIP,
-            $this->model->generateClass(\Magento\GeneratedClass\Factory::class)
+            Generator::GENERATION_SKIP,
+            $this->model->generateClass(GeneratedClassFactory::class)
         );
     }
 
-    /**
-     * @return array
-     */
     public function trueFalseDataProvider()
     {
         return [[true], [false]];
@@ -153,18 +223,5 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
             ];
         }
         return $data;
-    }
-
-    /**
-     * Build SUT object
-     *
-     * @param Io $ioObject
-     * @param array $generatedEntities
-     * @param DefinedClasses $definedClasses
-     * @return Generator
-     */
-    private function buildModel(Io $ioObject, array $generatedEntities, DefinedClasses $definedClasses)
-    {
-        return new Generator($ioObject, $generatedEntities, $definedClasses);
     }
 }

--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -99,7 +99,10 @@ class Format implements \Magento\Framework\Locale\FormatInterface
             $currency = $this->_scopeResolver->getScope()->getCurrentCurrency();
         }
 
-        $formatter = new \NumberFormatter($localeCode, \NumberFormatter::CURRENCY);
+        $formatter = new \NumberFormatter(
+            $localeCode . '@currency=' . $currency->getCode(),
+            \NumberFormatter::CURRENCY
+        );
         $format = $formatter->getPattern();
         $decimalSymbol = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $groupSymbol = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);

--- a/lib/web/css/source/lib/_tables.less
+++ b/lib/web/css/source/lib/_tables.less
@@ -530,7 +530,7 @@
                 display: block;
                 .lib-css(padding, @_table-responsive-cell-padding);
 
-                &:before {
+                &[data-th]:before {
                     .lib-css(padding-right, @table-cell__padding-horizontal);
                     content: attr(data-th)': ';
                     display: inline-block;

--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
@@ -114,7 +114,7 @@ class ClassesScanner implements ClassesScannerInterface
     /**
      * @param array $classNames
      * @param string $fileItemPath
-     * @return bool Whether the clas is included or not
+     * @return bool Whether the class is included or not
      */
     private function includeClasses(array $classNames, $fileItemPath)
     {

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/ConfigurationScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/ConfigurationScanner.php
@@ -28,7 +28,7 @@ class ConfigurationScanner
      *
      * @param string $fileName
      *
-     * @return array array of paths to the configuration files
+     * @return array of paths to the configuration files
      */
     public function scan($fileName)
     {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16607
Improve code quality with better spelling.

Added new public methods with correct name while added the `@deprecated`  annotation to the miss-spelled method name. These new old methods return the new methods. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
